### PR TITLE
alterações no arquivo yaml de constitucional e no readme sobre o diretório justify

### DIFF
--- a/README.org
+++ b/README.org
@@ -1,0 +1,4 @@
+
+A corpus with RAW text files from the (i) official OAB Exams and (ii) simulation exams provided by FGV DIREITO RIO.
+
+Obs: OAB Exams are the Brazilian version of the BAR exam (USA).

--- a/justify/README.md
+++ b/justify/README.md
@@ -1,36 +1,49 @@
-# justify.txt
+# fundamento-respostas.pdf
 
-contains the justification for some questions from the OAB exam in
-machine-readable format.
-
-a justification is the article and law which justifies the correct
-answer.
-
-the format is as follows (fields are separated by tabs):
-
-```
-year-edition	question_number	article_number	justification_URN	comments
-```
-
-- `year-edition`(YYYY-[0-9]{2}[a-z]{1}: the year and the edition of
-  the exam, plus an optional letter if its an exam reapplication.
-
-- `question_number` ([0-9]+): an integer.
-
-- `article_number` (art[0-9]+): if the article has a number and a
-  letter (as in the OAB regimento) use (art[0-9]+-[0-9]+) as LexML
-  recommends.
-
-- `justification_URN`: the URN of the legal norm that justifies the
-  correct answer (see [LexML URN](http://projeto.lexml.gov.br/documentacao/Parte-2-LexML-URN.pdf) and [XML Schema](http://projeto.lexml.gov.br/documentacao/Parte-3-XML-Schema.pdf)).
-
-- `comments`: any string without tabs (`\t`).
-
-# fundamento-respostas.tex
-
-contains the original justifications for 30 questions from the ethics
-section of the OAB exam.
+contains the original justifications for 30 questions from the ethics section of
+the OAB exam.
 
 # relatorio-wn-oabexams.docx
 
 a report on how well the Brazilian WordNet handles legal terms.
+
+# justify-constitutional.yaml and justify-ethics.yaml
+
+contains the justification for some questions from the OAB exam in
+machine-readable format.
+
+there are two files, one about constitutional questions and the other with
+questions on ethics.
+
+a justification is the article, subsection and law which justifies the correct
+answer.
+
+the format uses yaml with the following structure:
+
+``` 
+exam: 
+
+question: 
+
+urn: 
+
+article: 
+
+comment: 
+
+```
+
+- `exam`(YYYY-[0-9]{2}[a-z]{1}: the year and the edition of the exam, plus an
+  optional letter if its an exam reapplication.
+
+- `question` ([0-9]+): an integer.
+
+- `urn`: the URN of the legal norm that justifies the correct answer (see [LexML
+  URN](http://projeto.lexml.gov.br/documentacao/Parte-2-LexML-URN.pdf) and [XML
+  Schema](http://projeto.lexml.gov.br/documentacao/Parte-3-XML-Schema.pdf)).
+
+- `article` (art[0-9]+): if the article has a number and a letter (as in the OAB
+  regimento) use (art[0-9]+-[0-9]+) as LexML  recommends.
+
+- `comments`: any string without tabs (`\t`).
+

--- a/justify/justify-const.yaml
+++ b/justify/justify-const.yaml
@@ -1,8 +1,7 @@
 - exam: 2010-01
   question: 13
   urn: urn:lex:br:federal:lei:1999-11-10;9868
-  article: 12
-  subsection: caput
+  article: art12_cpt
   comment: |
     Essa questão tem dois pontos curiosos. Primeiro, apesar de ser de
     constitucional, a resposta não está na constituição, está na lei
@@ -13,10 +12,10 @@
 - exam: 2010-01
   question: 14
   urn: urn:lex:br:supremo.tribunal.federal;turma.2:acordao;re:2007-11-06;243157-3617899
-  article: ementa
-  subsection: |
-    Necessidade de autorização judicial ou decisão de Comissão
-    Parlamentar de Inquérito, ambas devidamente fundamentadas.
+  article:
+    ementa: |
+      Necessidade de autorização judicial ou decisão de Comissão
+      Parlamentar de Inquérito, ambas devidamente fundamentadas.
   comment: |
     Essa questão também chama atenção. A resposta, de acordo com a
     Banca Examinadora, está na jurisprudência, em uma decisão em turma
@@ -26,8 +25,7 @@
 - exam: 2010-01
   question: 16
   urn: urn:lex:br:federal:constituicao:1988-10-05;1988
-  article: 54
-  subsection:  I-b
+  article: art54_cpt_inc1_ali2
   comment: |
     Observe a redação do Artigo 54 da Constituição "Os Deputados e
     Senadores não poderão: I - desde a expedição do diploma: a) firmar
@@ -43,8 +41,7 @@
 - exam: 2010-02
   question: 1
   urn: urn:lex:br:federal:constituicao:1988-10-05;1988
-  article: 57
-  subsection: fourth-paragraph IV
+  article: art57_par4_inc4
   comment: |
     A resposta está na subsection da subsection, no inciso IV do
     parágrafo quarto.
@@ -52,8 +49,7 @@
 - exam: 2011-03
   question: 21
   urn: urn:lex:br:federal:constituicao:1988-10-05;1988
-  article: 5
-  subsection:  LXX
+  article: art5_cpt_inc70
   comment: |
     artigo 5 é gigante, ele tem 68 incisos! A resposta está no inciso
     70, definição de mandado coletivo.
@@ -61,8 +57,7 @@
 - exam: 2011-04
   question: 13
   urn: urn:lex:br:federal:constituicao:1988-10-05;1988
-  article: 5
-  subsection: third-paragraph
+  article: art5_par3
   comment: |
     O aluno precisava perceber que "Convenção Internacional sobre os
     Direitos das Pessoas com Deficiência" entra dentro de "tratados e
@@ -72,8 +67,7 @@
 - exam: 2011-05
   question: 18
   urn: urn:lex:br:federal:lei:2006-12-19;11417
-  article: 3
-  subsection:  X
+  article: art3_cpt_inc10
   comment: |
     A questão é sobre cancelamento de súmula vinculante e envolve a
     lei 11417 de 2006. A súmula vinculante é um instituto do direito
@@ -85,7 +79,6 @@
   question: 17
   urn:
   article:
-  subsection:
   comment: |
     Essa questão é bem interessante. Ela pergunta algo que não existe
     consenso entre os teóricos.  O gabarito assume a visão
@@ -105,31 +98,29 @@
 - exam: 2012-06a
   question: 16
   urn: urn:lex:br:federal:constituicao:1988-10-05;1988
-  article: 103
-  subsection: third-paragraph
+  article: art103_par3
   comment: O texto da lei "chapa" bem com o que foi perguntado.
 
 - exam: 2012-07
   question: 20
   urn: urn:lex:br:federal:constituicao:1988-10-05;1988
-  article: 12
-  subsection: third-paragraph V
+  article: art12_par3_inc5
   comment: O texto da lei "chapa" bem com o que foi perguntado.
 
 - exam: 2012-08
   question: 13
   urn: urn:lex:br:federal:constituicao:1988-10-05;1988
-  article: 95  98
-  subsection: 95-II 98-VIII
+  article: 
+    - art95_cpt_inc2 
+    - art98_cpt_inc8
   comment:  |
-    A resposta está no 95-II, o ponto legal é que o pro inciso II do 95
-    cita o VIII do 98
+    A resposta está no 95-II, o ponto legal é que o próprio inciso II do
+    95 cita o VIII do 98.
 
 - exam: 2012-9
   question: 14
   urn: urn:lex:br:federal:constituicao:1988-10-05;1988
-  article: 22
-  subsection: II
+  article: art22_cpt_inc2
   comment: |
     A questão pede pro candidato falar sobre a legislação envolvendo
     desapropriação.  Todas as alternativas, por sua vez, fazem
@@ -141,22 +132,19 @@
 - exam: 2013-10
   question: 13
   urn: urn:lex:br:federal:constituicao:1988-10-05;1988
-  article: 60
-  subsection: first-paragraph
+  article: art60_par1
   comment: o texto da lei "chapa" bem com a pergunta
 
 - exam: 2013-11
   question: 13
   urn: urn:lex:br:federal:constituicao:1988-10-05;1988
-  article: 210
-  subsection: second-paragraph
+  article: art210_par2
   comment: a alternativa é basicamente a redação do artigo
 
 - exam: 2013-12
   question: 13
   urn: urn:lex:br:federal:constituicao:1988-10-05;1988
-  article: 5
-  subsection: XVI
+  article: art5_cpt_inc16
   comment: |
     Essa questão usa negativa, tem que escolher a errada, todas as
     outras certas.  A alternativa diz que precisa de autorização de
@@ -166,22 +154,19 @@
 - exam: 2014-13
   question: 13
   urn: urn:lex:br:federal:constituicao:1988-10-05;1988
-  article: 18
-  subsection: fourth-paragraph
+  article: art18_par4
   comment: No parágrafo quarto aparecem os dois requisitos citados na alternativa.
 
 - exam: 2014-13
   question: 17
   urn: urn:lex:br:federal:constituicao:1988-10-05;1988
-  article: 84
-  subsection: sole-paragraph
+  article: art84_par1u 
   comment: O parágrafo único faz menção a vários incisos, respondendo a questão.
 
 - exam: 2014-14
   question: 14
   urn: urn:lex:br:federal:constituicao:1988-10-05;1988
-  article: 34
-  subsection: VI
+  article: art34_cpt_inc6
   comment: |
     O Estado estava descumprindo lei federal 8666. Cabe intervenção da União
     para fazer o Estado cumpir.  Detalhe que o comando do caput do artigo 34
@@ -190,15 +175,15 @@
 - exam: 2014-15
   question: 13
   urn: urn:lex:br:federal:constituicao:1988-10-05;1988
-  article: 55
-  subsection:  III   third-paragraph
+  article:
+    - art55_cpt_inc3
+    - art55_par3
   comment: Essa questão está justificada em duas "subsections" do artigo 55.
 
 - exam: 2015-16
   question: 13
   urn: urn:lex:br:federal:constituicao:1988-10-05;1988
-  article: 12
-  subsection: third-paragraph III
+  article: art12_par3_inc3
   comment: |
     Essa questão também merece ser destacada. Existem duas formas de ser cidadão
     brasileiro: brasileiro nato ou naturalizado.  O artigo 12 da CRFB/88 diz
@@ -211,8 +196,7 @@
 - exam: 2015-17
   question: 13
   urn: urn:lex:br:federal:constituicao:1988-10-05;1988
-  article: 60
-  subsection: fourth-paragraph
+  article: art60_par4
   comment: |
     A justificativa dessa questão não está totalmente na lei. A lei não usa o
     termo "constituinte derivado reformador". Além disso, a própria constituição
@@ -223,7 +207,6 @@
   question: 14
   urn:
   article:
-  subsection:
   comment: |
     A justificativa dessa questão está na doutrina (teoria constitucional).  Não
     pode ser encontrada diretamente em nenhum artigo da constituição.
@@ -231,8 +214,7 @@
 - exam: 2015-18
   question: 15
   urn: urn:lex:br:federal:constituicao:1988-10-05;1988
-  article: 81
-  subsection: first-paragraph
+  article: art81_par1
   comment: |
     Art. 81. Vagando os cargos de Presidente e Vice-Presidente da República,
     far-se-á eleição noventa dias depois de aberta a  última vaga.  § 1º
@@ -243,8 +225,11 @@
 - exam: 2016-19
   question: 13
   urn: urn:lex:br:federal:constituicao:1988-10-05;1988
-  article: 14
-  subsection: third-paragraph-IV third-paragraph-VI-a third-paragraph-VI-b third-paragraph-VI-c
+  article: 
+    - art14_par3_inc4
+    - art14_par3_inc6_ali1 
+    - art14_par3_inc6_ali2 
+    - art14_par3_inc6_ali3
   comment: |
     Uma das condições de elegibilidade é o domicílio eleitoral coincidir com a
     circunscrição da candidatura.  André é do Estado E, ele não pode ser
@@ -257,8 +242,9 @@
 - exam: 2016-20
   question: 14
   urn: urn:lex:br:federal:constituicao:1988-10-05;1988
-  article: 73 75
-  subsection: §1º-I caput
+  article:
+    - art73_par1_inc1
+    - art75_cpt
   comment: |
     Essa questão exige a interpretação conjugada de dois artigos, além do uso de
     um princípio da doutrina: o princípio da simetria, isto é, as Constituições
@@ -271,15 +257,13 @@
 - exam: 2016-20a
   question: 13
   urn: urn:lex:br:federal:constituicao:1988-10-05;1988
-  article: 66
-  subsection: fourth-paragraph
+  article: art66_par4
   comment: Nessa questão a alternativa correta é bem semelhante à redação normativa.
 
 - exam: 2016-21
   question: 13
   urn: urn:lex:br:federal:constituicao:1988-10-05;1988
-  article: 194
-  subsection: caput
+  article: art194_cpt
   comment: |
     Essa questão cobra basicamente a definição constitucional de seguridade
     social. O caput define.
@@ -288,7 +272,6 @@
   question: 16
   urn: urn:lex:br:supremo.tribunal.federal:sumula:2003-09-24;683
   article:
-  subsection:
   comment: |
     A resposta dessa questão está na súmula vinculante 683 do STF. A
     constituição define que não pode ocorrer discriminação no concurso público
@@ -299,15 +282,13 @@
 - exam: 2017-23
   question: 13
   urn: urn:lex:br:federal:constituicao:1988-10-05;1988
-  article: 210
-  subsection: first-paragraph
+  article: art210_par1
   comment: Nessa questão a alternativa correta é bem semelhante à redação normativa.
 
 - exam: 2017-24
   question: 13
   urn: urn:lex:br:federal:constituicao:1988-10-05;1988
-  article: 5
-  subsection: XXXVII
+  article: art5_cpt_inc37
   comment: |
     O artigo 5 é gigante, nele são definidos direitos fundamentais criados
     dentro da matriz de pensamento liberal, como liberdade de expressão,

--- a/justify/lexml-conventions.md
+++ b/justify/lexml-conventions.md
@@ -1,0 +1,15 @@
+## LexML conventions for legal subsections
+
++ cpt -> caput
+
++ par1u -> paragráfo único
+
++ inc1 -> inciso primeiro
+
++ par1 -> parágrafo primeiro
+
++ art34\_par1u\_ali1 -> artigo 34, parágrafo único, alínea a). Destaque a) vira 1.
+
++ inc8 -> inciso oitavo
+
+


### PR DESCRIPTION
Nesse PR tem dois commits importantes. O primeiro commit é um aprimoramento do arquivo justity-consti.yaml

Com as  ótimas sugestões do @odanoburu, alterei a indicação da onde estava a resposta no artigo e resolvi um problema de ambiguidade da versão anterior. Ao invés de inventar uma forma de me referir a normas, usei as convenções da estrutura do Lexml Brasil. Por exemplo, art43_cpt_inc23, indica que quero me referir ao artigo 43, inciso XXIII, sendo que esse inciso não está dentro de parágrafos e sim dentro do caput do artigo. Essa convenção é boa e, por exemplo, foge de problemas com número romano.

O outro commit foi reescrever o README sobre o diretório justify. Como alguns arquivos foram deletados e outros adicionados, era necessário reescrever.

