### PR TITLE
script para limpar dados simulated e alterações automáticas no arquivo 2011-5.txt

### DIFF
--- a/simulated/raw/2011-5-w.txt
+++ b/simulated/raw/2011-5-w.txt
@@ -1,0 +1,1205 @@
+
+Administrativo
+
+
+1. (FGV - 2010) O atributo pelo qual atos administrativos se impõem a terceiros, ainda que de forma contrária a sua concordância, é denominado: 
+
+
+OPTIONS 
+
+A) Competência. 
+
+B) Veracidade. 
+
+C) Vinculação. 
+
+D) Imperatividade. 
+
+---
+ENUM Questão 
+
+2. (OAB/Exame Unificado - 2009.1) Assinale a opção correta acerca dos bens públicos. 
+
+
+OPTIONS 
+
+A) Consideram-se privados os bens pertencentes às pessoas jurídicas de direito público aos quais a lei tenha dado estrutura de direito privado. 
+
+B) Considera-se bem público de uso comum o bem público imóvel onde funcione repartição pública. 
+
+C) Depende de prévia aprovação do Congresso Nacional a alienação ou cessão de terras públicas, de qualquer tamanho, incluindo-se as destinadas à reforma agrária. 
+
+D) Pode ser autorizada por meio de permissão de uso a utilização, a título precário, de bens públicos imóveis federais para a realização de eventos de curta duração, de natureza recreativa, esportiva, cultural, religiosa ou educacional. 
+
+---
+ENUM Questão 
+
+3. (OAB/Exame Unificado - 2008.3) Referentemente aos contratos administrativos, assinale a opção correta. 
+
+
+OPTIONS 
+
+A) A presença da administração pública na relação contratual é suficiente para se qualificarem aven - ças no contrato administrativo. 
+
+B) O principio da continuidade do serviço público impede que o contratado suspenda, sob a alega - ção de falta de pagamento, o serviço que presta à administração pública. 
+
+C) As cláusulas exorbitantes possibilitam à adminis - tração pública alterar unilateralmente o contrato administrativo, exceto no que se refere à manu - tenção do equilíbrio econômico-financeiro. 
+
+D) A modificação da finalidade da empresa con - tratada pela administração para prestação de serviços implica automática rescisão do contrato administrativo. 
+
+---
+ENUM Questão 
+
+4. (OAB/Exame Unificado - 2008.3) No que diz respeito à improbidade administrativa, julgue os itens a seguir. 
+
+
+I. De acordo com a lei, a ação de improbidade não pode ser cumulada com pedido de danos morais. 
+
+II. O juiz deve, antes de determinar a citação da ação de improbidade, proceder à notificação prévia do acusado. 
+
+III. O prazo prescricional de ato de improbidade de governador começa a fluir da data em que tenha sido praticado o ato. 
+
+IV. A Lei de Improbidade Administrativa não prevê a gradação das penas que prescreve, não sendo admitida, em consequência, a aplicação da proporcionalidade da pena. 
+
+V. Na avaliação da improbidade por dano ao erário, o juiz deve analisar o elemento subjetivo da conduta do agente. 
+
+
+Estão certos apenas os itens: 
+
+
+OPTIONS 
+
+A) I e III. 
+
+B) I e V. 
+
+C) II e IV. 
+
+D) II e V. 
+
+---
+ENUM Questão 
+
+5. (OAB/Exame Unificado - 2008.3) Assinale a opção correta acerca de desapropriação. 
+
+OPTIONS 
+
+A) A desapropriação indireta, forma legítima de inter - venção na propriedade, é realizada por entidade da administração indireta. 
+
+B) OS bens públicos não podem ser desapropriados. 
+
+C) Em caso de desapropriação por interesse social para fim de reforma agrária, deve haver indeni - zação, necessariamente em dinheiro, das benfei - torias úteis e das necessárias. 
+
+D) A desapropriação de imóveis urbanos pode ser feita mediante prévia e justa indenização, permi - tindo-se à administração, caso haja autorização legislativa do Senado Federal, pagá-la com títulos da divida pública. 
+
+---
+ENUM Questão 
+
+6. (FGV - 2008) Assinale a alternativa correta. 
+
+
+OPTIONS 
+
+A) O principio da oralidade é o principio diferencial do pregão em relação às modalidades clássicas de licitação. 
+
+B) Na inexigibilidade de licitação, esta é material - mente possível, mas, em regra, inconveniente. 
+
+C) Tomada de Preço é a modalidade de licitação adequada a contratações de grande vulto; apresenta maior rigor formal em seu procedi - mento, se comparada às outras modalidades licitatórias. 
+
+D) Os bens imóveis da Administração Pública cuja aquisição haja derivado de procedimentos judi - ciais ou de dação em pagamento poderão ser alienados por licitação, sob as modalidades de convite ou leilão. 
+
+---
+ENUM Questão 
+
+7. (OAB/Exame Unificado - 2007.2) Acerca dos órgãos públi - cos, assinale a opção correta. 
+
+
+OPTIONS 
+
+A) É correto, do ponto de vista da natureza jurídica do órgão, afirmar que "João propôs uma ação de rito ordinário contra a receita federal". 
+
+B) Alguns órgãos públicos têm capacidade proces - sual, já que são titulares de direitos subjetivos próprios a serem defendidos. 
+
+C) A teoria que melhor explica a relação existente entre o servidor público e a pessoa juridica do Estado é a teoria da representação, cuja caracte - rística principal consiste no princípio da imputação volitiva. Assim, a vontade do órgão público é impu - tada à pessoa jurídica a cuja estrutura pertence, já que aquele estaria agindo em seu nome. 
+
+D) A organização da administração pública direta, no que se refere à estruturação dos órgãos e competência, é matéria reservada á lei. 
+
+---
+ENUM Questão 
+
+8. (OAB/Exame Unificado - 2007.3) Assinale a opção correta acerca dos princípios da administração pública. 
+
+
+OPTIONS 
+
+A) O principio da eficiência não constava expres - samente do texto original da CF, tendo sido inserido posteriormente, por meio de emenda constitucional. 
+
+B) O princípio da motivação determina que os moti - vos do ato praticado devam ser determinados pelo mesmo órgão que tenha tomado a decisão. 
+
+C) Embora seja consagrado pela jurisprudência e pela doutrina, o principio da impessoalidade não foi consagrado expressamente na CF. 
+
+D) Em virtude do princípio da legalidade, a adminis - tração pública somente pode impor obrigações em virtude de lei; direitos, por sua vez, podem ser concedidos por atos administrativos. 
+
+---
+ENUM Questão 
+
+9. (OAB/Exame Unificado - 2008.2) Assinale a opção correta com relação às normas que regulam o processo administrativo no âmbito da administração pública federal. 
+
+
+OPTIONS 
+
+A) As normas que regulam o processo administra - tivo no âmbito da administração pública federal aplicam-se apenas à administração pública direta. 
+
+B) As normas que regulam o processo administrativo no âmbito da administração pública federal são aplicáveis apenas ao Poder Executivo. 
+
+C) O administrado tem o direito de ter ciência da tramitação dos processos administrativos em que tenha a condição de interessado bem como de ter vista dos autos, obter cópias de documentos neles contidos e conhecer as decisões proferidas. 
+
+D) O processo administrativo tem seu início sempre por iniciativa da própria administração pública. 
+
+---
+ENUM Questão 
+
+
+10. (OAB/Exame Unificado - 2007.3) Recente decisão do STF entendeu que a garantia constitucional de respon - sabilidade objetiva de pessoa privada que preste serviço público volta-se apenas ao usuário desse serviço público. De acordo com esse entendimento, não corresponderiam a caso de responsabilidade objetiva danos causados a proprietário 
+
+
+OPTIONS 
+
+A) De restaurante, em decorrência de suspensão por 24 horas do fornecimento de energia elétrica. 
+
+B) De veiculo que, em decorrência de buracos em uma estrada privatizada, tenha sofrido acidente com perda parcial do veiculo. 
+
+C) de veiculo abalroado por ônibus de empresa de transporte coletivo. 
+
+D) De hotel, por suspensão, sem motivo, do serviço de distribuição de gás canalizado. 
+
+---
+ENUM Questão 
+
+
+Constitucional
+
+
+11. Sobre a nacionalidade brasileira, é CORRETO afirmar:
+
+
+OPTIONS 
+
+A) Qualquer cargo eletivo do país pode ser ocupado por brasileiro naturalizado, como é o caso do Vice Presidente da República.
+
+B) A naturalização extraordinária será concedida ao originário de país de língua portuguesa após a comprovação de residência por um ano no país e idoneidade moral.
+
+C) As hipóteses de aquisição de nacionalidade derivada estão taxativamente previstas na Constituição Federal e não podem ser ampliadas por legislação ordinária.
+
+D) Os nascidos no estrangeiro entre 7 de junho de 1994 e a data da promulgação da Emenda Constitucional 54/07, filhos de pai brasileiro ou mãe brasileira, poderão ser registrados em repartição diplomática ou consular brasileira competente ou em ofício de registro, se vierem a residir na República Federativa do Brasil.
+
+---
+ENUM Questão 
+
+12. Sobre a teoria geral da Constituição, assinale a alternativa correta:
+
+
+OPTIONS 
+
+A) Podemos dizer que as Constituições não escritas são desprovidas de documentos escritos reconhecidos como Constituição.
+
+B) As normas constitucionais de eficácia limitada não produzem nenhum efeito jurídico.
+
+C) As Constituições dogmáticas estão associadas, via de regra, às Constituições escritas.
+
+D) Quanto ao modo de elaboração a Constituição de 1988 é histórica, tendo em vista que foi fruto das manifestações contra a ditadura que a antecedeu.
+
+---
+ENUM Questão 
+
+13. "Art. 215. O Estado garantirá a todos o pleno exercício dos direitos culturais e acesso às fontes da cultura nacional, e apoiará e incentivará a valorização e a difusão das manifestações culturais". Podemos dizer que o artigo reproduzido indica que a nossa Constituição é: 
+
+
+OPTIONS 
+
+A) Outorgada
+
+B) Histórica
+
+C) Promulgada
+
+D) Dirigente
+
+---
+ENUM Questão 
+
+14. Vários Deputados, em número constitucional suficiente, apresentam proposta de Emenda Constitucional visando aumentar a duração da licença à gestante, sem prejuízo do emprego e do salário, para cento e oitenta dias. Sobre a referida proposta, assinale a alternativa correta:
+
+
+OPTIONS 
+
+A) A proposição pode ser aprovada ou rejeitada, segundo a vontade dos legisladores;
+
+B) Tal medida só pode ser proposta pelas Assembléias Legislativas;
+
+C) Não pode ser objeto de deliberação por expressa disposição constitucional;
+
+D) Tal proposição necessitará da participação do Presidente da República por meio da sanção ou veto.
+
+---
+ENUM Questão 
+
+15. Sobre os direitos fundamentais, assinale a alternativa correta:
+
+
+OPTIONS 
+
+A) Os direitos fundamentais se aplicam às relações Estado-indivíduo e indivíduo-indivíduo também.
+
+B) Os direitos de 2ª geração são os direitos de manipulação genética, relacionados à biotecnologia e aos avanços tecnológicos.
+
+C) A 4ª dimensão é caracterizada pela exigência dos indivíduos ao Estado para a implementação de políticas públicas;
+
+D) Os direitos fundamentais são inexigíveis, imprescritíveis e inalienáveis. 
+
+---
+ENUM Questão 
+
+16. Sabe-se que a Constituição em vigor prevê que matéria geral sobre direito tributário deve ser tratada por meio de lei complementar. Sabendo que o Código Tributário Nacional (CTN) foi editado antes da Constituição de 1988, sob a forma de lei ordinária, é possível afirmar que as normas do CTN que regulam limitações constitucionais ao poder de tributar:
+
+
+OPTIONS 
+
+A) Devem ser consideradas revogadas com o advento da nova Constituição.
+
+B) Devem ser consideradas formalmente inconstitucionais e, por isso, insuscetíveis de produzir efeitos, pelo menos a partir da Constituição de 1988.
+
+C) Continuam a produzir efeitos na vigência da nova Carta, por força do mecanismo da recepção.
+
+D) Devem ser consideradas repristinadas, podendo produzir efeitos parciais.
+
+---
+ENUM Questão 
+
+17. Sobre o Poder Executivo brasileiro, assinale a opção correta.
+
+
+OPTIONS 
+
+A) Os ministros do Supremo Tribunal Federal podem ser chamados a suceder o presidente, por ordem de antiguidade;
+
+B) A lista de convocação de autoridades tanto no caso de impedimento quanto no de vacância obedece à mesma ordem.
+
+C) Por crime comum o presidente da República é julgado pelo STF e por crime de responsabilidade pelo Senado Federal. Em ambos os casos a Câmara dos Deputados deverá realizar o juízo de admissibilidade quanto à acusação.
+
+D) Governadores e Prefeitos gozam das mesmas imunidades do presidente da República;
+
+---
+ENUM Questão 
+
+
+18. Sobre o controle de constitucionalidade das leis no Brasil, responda  ao quesito correto:
+
+
+I- O controle de constitucionalidade pode ser difuso ou concentrado.
+
+II- Não há inconstitucionalidade por ação, somente por omissão.
+
+III- A supremacia constitucional é um dos princípios de destaque do controle de constitucionalidade
+
+IV-  Todas as normas constitucionais gozam de presunção absoluta de constitucionalidade
+
+
+Estão corretas:
+
+
+OPTIONS 
+
+A) I e II;
+
+B) I e III;
+
+C) I , III e IV;
+
+D) II e IV;
+
+---
+ENUM Questão 
+
+19. Medida Provisória que alterasse o procedimento sumário previsto no Código de
+
+Processo Civil e que fosse prorrogada por mais 60 (sessenta) dias, durante a
+
+vigência de estado de sítio,
+
+
+OPTIONS 
+
+A) Não deveria ser convertida em lei, porque a prorrogação só é admitida por mais 30 (trinta) dias, prorrogáveis uma vez por igual período;
+
+B) Não deveria ser convertida em lei, porque não pode dispor sobre direito processual civil;
+
+C) Não deveria ser convertida em lei, porque não poderia ser prorrogada sob a vigência de estado de sítio;
+
+D) Deveria ser convertida em lei, porque foi produzida nos termos da Constituição Federal.
+
+---
+ENUM Questão 
+
+20. Determinado projeto de lei de iniciativa popular é primeiramente discutido, votado e aprovado sem emendas no Senado Federal, seguindo para a Câmara dos Deputados, onde também é discutido, votado e aprovado sem emendas, sendo então enviado ao presidente da República, para sancioná-lo ou vetá-lo no prazo de 15 dias úteis, contados da datas do recebimento. Todavia, o Presidente da República resta silente, sendo, pois, o projeto considerado vetado. Considerando exclusivamente os aspectos mencionados, nessa situação foram: 
+
+
+OPTIONS 
+
+A) Desrespeitadas apenas as regras constitucionais quanto ao prazo para sanção ou veto e quanto aos efeitos do silêncio do Presidente da República; 
+
+B) Desrespeitadas apenas as regras constitucionais quanto à ordem de votação entre as casas legislativas e quanto aos efeitos do silêncio do Presidente da República;
+
+C) Desrespeitadas as regras constitucionais quanto à ordem de votação entre as casas legislativas, quanto ao prazo para sanção ou veto e quanto aos efeitos do silêncio do Presidente da República;
+
+D) Desrespeitadas todas as regras constitucionais quanto ao processo legislativo.
+
+---
+ENUM Questão 
+
+
+Deontologia
+
+
+21  -  O advogado Pedro Freitas, regularmente inscrito na OAB/RJ, foi eleito em assembléia de acionistas e empossado Presidente do Banco Real. Como fica a situação desse advogado junto à OAB/RJ e quanto ao exercício da Advocacia? 
+
+OPTIONS 
+
+A)  O advogado terá sua inscrição na OAB/RJ cancelada e, conseqüentemente não poderá mais exercer a advocacia; 
+
+B)  O advogado será licenciado pela OAB/RJ e, por conseqüência, não poderá exercer a advocacia durante o tempo em que for Presidente do Banco Real; 
+
+C) O advogado continuará inscrito na OAB/RJ e exercendo a advocacia, ficando, porém, impedido de advogar contra o Banco Real; 
+
+D) O advogado continuará inscrito na OAB-RJ e exercendo a advocacia normalmente, sem qualquer restrição, por se tratar de Banco privado. 
+
+---
+ENUM Questão 
+22  -  Infringe disposição expressa do Código de Ética e Disciplina da OAB o advogado que: 
+
+OPTIONS 
+
+A) Renuncia ao mandato outorgado por um cliente, mesmo contra a vontade deste; 
+
+B) Recusa-se a atuar numa causa cível, quando for imposição do cliente que o advogado trabalhe com outro advogado indicado pelo cliente; 
+
+C) Publica anuncio em jornal de grande circulação, informando, além do nome e número de inscrição na OAB, ser ele integrante do Instituto de Estudos Criminais do Estado do Rio de Janeiro  -  Iecerj;
+
+D) Faz emitir uma nota promissória ao cliente para garantia do pagamento de seus honorários. 
+
+---
+ENUM Questão 
+23 - Em razão de acidente de motocicletas provocado por Carlos da Silva, este pagou a João Rocha, em composição amigável, a quantia de R$ 10.000 (dez mil reais) pelos danos materiais causados na motocicleta de João Rocha, que deu quitação do que lhe era devido. Passados 5 (cinco) meses, João Rocha procurou o advogado Caio das Neves e este, mesmo tendo ciência daquele acordo, foi contratado por João Rocha e ingressou em juízo com uma Ação de Ressarcimento de Danos por acidente de veículos contra Carlos da Silva, pleiteando a indenização de R$ 10.000,00 (dez mil reais) pelos danos materiais causados no veículo de João Rocha. Marque a alternativa correta: 
+
+OPTIONS 
+
+A) O advogado cometeu patrocínio simultâneo e fraude processual; 
+
+B) O advogado praticou uma lide temerária; 
+
+C) O advogado cometeu uma inépcia profissional; 
+
+D) O advogado cometeu tergiversação. 
+
+---
+ENUM Questão 
+24  -  Marque a opção que indique em que casos uma pessoa que não é advogada pode ingressar em juízo pessoalmente, isto é, sem se fazer representar por um advogado? 
+
+OPTIONS 
+
+A) Apenas na impetração de Habeas Corpus e no Juizado Especial Cível até 20 (vinte) salários mínimos; 
+
+B) Na impetração de Habeas Corpus, na Justiça do Trabalho (1ª Instância), no Juizado Especial Cível (até 20 salários mínimos) e no Mandado de Segurança; 
+
+C) Na impetração de Habeas Corpus, no Juizado Especial Cível até 20(vinte) salários mínimos, na Justiça do Trabalho (1ª Instância) e no Juizado de Paz (embora este último não seja um órgão jurisdicional); 
+
+D) Na impetração de Habeas Corpus, no Juizado Especial Cível até 20 (vinte) salários mínimos, na Justiça do Trabalho (1ª Instância), no Juizado de Paz e na Ação Popular. 
+
+---
+ENUM Questão 
+25  -  O advogado Jorge Dias, que tem domicílio profissional na cidade do Rio de Janeiro e está inscrito apenas na OAB/RJ, irá atuar em defesa de um cliente em uma ação penal proposta pelo Ministério Público na Comarca de Salvador/BA. Qual o procedimento a ser seguido pelo advogado? 
+
+OPTIONS 
+
+A) Terá que fazer uma inscrição suplementar na OAB/BA; 
+
+B) Terá que fazer a transferência de sua inscrição para a OAB/BA; 
+
+C) Poderá patrocinar atuar naquela ação na Bahia, sem inscrição na OAB/BA, mas desde que comunique o patrocínio à OAB/BA e OAB/RJ; 
+
+D) Poderá patrocinar atuar naquela causa na Bahia, sem inscrição e sem qualquer comunicação à OAB.
+
+---
+ENUM Questão 
+26 - Um advogado que está regularmente inscrito na OAB/RJ é escolhido em lista tríplice pelo Governador e empossado no cargo de Desembargador do Tribunal de Justiça do Estado do Rio de Janeiro. Como fica a situação daquele advogado junto à OAB/RJ?
+
+OPTIONS 
+
+A)     O advogado continuará inscrito na OAB/RJ e exercendo livremente a advocacia;
+
+B)     O advogado continuará inscrito na OAB/RJ, ficando, entretanto, proibido de advogar apenas contra a Fazenda que o remunera;
+
+C)     O advogado terá sua inscrição na OAB/RJ cancelada e, em razão disso, não poderá mais exercer a advocacia enquanto for membro do Poder Judiciário;
+
+D)     O advogado será licenciado da advocacia, não podendo advogar apenas durante o tempo em que exercer a atividade de Desembargador.
+
+---
+ENUM Questão 
+27  -  Carlos Nogueira, advogado do autor, quando fazia a sustentação oral numa Audiência de Instrução e julgamento, na 5ª Vara Cível da Comarca da Capital do Estado do Rio de Janeiro, injuriou e difamou advogado do réu. Sabendo-se que o advogado goza de imunidade profissional (art. 7º, § 2º, da Lei n° 8.906/94), pergunta se: o que pode acontecer com o advogado do autor? 
+
+OPTIONS 
+
+A)     Nada acontecerá ao advogado do autor em razão da imunidade profissional;
+
+B)     Ser processado criminalmente pela injúria e difamação proferidas;
+
+C)     Ser advertido pelo juiz da 5ª Vara Cível;
+
+D)     Ser apenas processado e punido pela OAB/RJ;
+
+---
+ENUM Questão 
+28  -  Caso um advogado, que já foi punido com a sanção de censura pela OAB/RJ, deixe de pagar a OAB, depois de regularmente notificado pela OAB, e, mesmo assim, não efetuar o pagamento, nem fazer o parcelamento, qual a punição disciplinar poderá ser aplicada àquele advogado? 
+
+OPTIONS 
+
+A)     Censura;
+
+B)     Suspensão pelo prazo de trinta dias a doze meses;
+
+C)     Exclusão;
+
+D)     Suspensão, pelo prazo mínimo de trinta dias, podendo se estender até que pague integralmente a OAB, cumulada com multa de uma a dez anuidades.
+
+---
+ENUM Questão 
+
+29  -  Sobre órgãos da OAB, de acordo com o EAOAB, é incorreto afirmar:
+
+
+OPTIONS 
+
+A) De acordo com o atual EAOAB, o Conselho Federal é formado por conselheiros federais integrantes das delegações de cada unidade federativa mais os ex-presidentes que tomaram posse até 1994, pois, de acordo com a nova Lei, não mais integrarão o Conselho Federal aqueles ex-presidentes que passaram a exercer a atividade após o mesmo ano.
+
+B) Todos os órgãos possuem personalidade jurídica, exceto as subseções.
+
+C) A Caixa de Assistência dos Advogados tem como base territorial a mesma dos Conselhos Seccionais, ou seja, estados, DF e territórios.
+
+D) O Conselho Seccional é composto pelos conselheiros seccionais em número proporcional ao número de advogados inscritos, bem como pelos ex-presidentes do Conselho Seccional.
+
+---
+ENUM Questão 
+
+
+30  -  Constitui direito do advogado:
+
+
+OPTIONS 
+
+A) visitar seu cliente que esteja preso em estabelecimento penitenciário, desde que tenha procuração;
+
+B) obter vista dos autos de um processo sob segredo de justiça, mesmo sem procuração;
+
+C) exercer a profissão em todo o território nacional, independentemente do número de causas em cada estado.
+
+D)  usar a expressão "pela ordem" em qualquer juízo para replicar censura que lhe for feita durante o julgamento.
+
+---
+ENUM Questão 
+
+
+Direito e Processo Penal
+
+
+31- Com relação ao concurso de delitos, é correto afirmar que:
+
+
+OPTIONS 
+
+A) No concurso de crimes as penas de multa são aplicadas distintamente, mas de forma reduzida.
+
+B) O concurso material ocorre quando o agente, mediante mais de uma ação ou omissão, pratica dois ou mais crimes com dependência fática e jurídica entre estes.
+
+C) O concurso formal perfeito, também conhecido como próprio, ocorre quando o agente, por meio de uma só ação ou omissão, pratica dois ou mais crimes idênticos, caso em que as penas serão somadas.
+
+D) O Código Penal Brasileiro adotou o sistema de aplicação de pena do cúmulo material para os concursos material e formal imperfeito, e da exasperação para o concurso formal perfeito e crime continuado.
+
+---
+ENUM Questão 
+
+32- A respeito do regime legal da prescrição no Código Penal, tendo por base ocorrência do fato na data de hoje, assinale a alternativa correta.
+
+
+OPTIONS 
+
+A) A prescrição, depois da sentença condenatória com trânsito em julgado para a acusação, regula-se pela pena aplicada, não podendo, em nenhuma hipótese, ter por termo inicial data anterior à da denúncia ou queixa.
+
+B) A prescrição da pena de multa ocorrerá em 2 (dois) anos, independentemente do prazo estabelecido para a prescrição da pena de liberdade aplicada cumulativamente.
+
+C) Se o réu citado por edital permanece revel e não constitui advogado, fica suspenso o processo, mantendo-se em curso o prazo prescricional, que passa a ser computado pelo dobro da pena máxima cominada ao crime.
+
+D) São causas interruptivas do curso da prescrição previstas no Código Penal, dentre outras, o recebimento da denúncia ou da queixa, a pronúncia, a publicação da sentença condenatória ou absolutória recorrível.
+
+---
+ENUM Questão 
+
+33- Em 7 de fevereiro de 2010, Ana, utilizando-se do emprego de grave ameaça, constrange seu amigo Lucas, bem-sucedido advogado, a com ela praticar ato libidinoso diverso da conjunção carnal. Em 7 de agosto de 2010, Lucas comparece à delegacia policial para noticiar o crime, tendo sido instaurado inquérito a fim de apurar as circunstâncias do delito. 
+
+A esse respeito, é correto afirmar que o promotor de justiça
+
+
+OPTIONS 
+
+A) Deverá oferecer denúncia contra Ana pela prática do crime de atentado violento ao pudor, haja vista que, por se tratar de crime hediondo, a ação penal é pública incondicionada. 
+
+B) Nada poderá fazer, haja vista que os crimes sexuais, que atingem bens jurídicos personalíssimos da vítima, só são persequíveis mediante queixa-crime. 
+
+C) Deverá pedir o arquivamento do inquérito por ausência de condição de procedibilidade para a instauração de processo criminal, haja vista que a ação penal é pública condicionada à representação, não tendo a vítima se manifestado dentro do prazo legalmente previsto para tanto. 
+
+D) Deverá oferecer denúncia contra Ana pela prática do crime de estupro, haja vista que, com a alteração do Código Penal, passou-se a admitir que pessoa do sexo masculino seja vítima de tal delito, sendo a ação penal pública incondicionada. 
+
+---
+ENUM Questão 
+
+34 - Guiando o seu automóvel na contramão de direção, em outubro de 2010, Tício é perseguido por uma viatura da polícia militar. Após ser parado pelos agentes da lei, Tício realiza, espontaneamente, o exame do etilômetro e fornece aos militares sua habilitação e o documento do automóvel. No exame do etilômetro, fica constatado que Tício apresentava concentração de álcool muito superior ao patamar previsto na legislação de trânsito. Além disso, os policiais constatam que o motorista estava com a habilitação vencida desde maio de 2009. 
+
+Com relação ao relatado acima, é correto afirmar que o promotor de justiça deverá denunciar Tício:
+
+
+OPTIONS 
+
+A) Pela prática dos crimes de embriaguez ao volante e direção sem habilitação 
+
+B) Apenas pelo crime de embriaguez ao volante, uma vez que o fato de a habilitação estar vencida constitui mera infração administrativa. 
+
+C) Apenas pelo crime de direção sem habilitação, uma vez que o perigo gerado por tal conduta faz com que o delito de embriaguez ao volante seja absorvido, em razão da aplicação do Princípio da Consunção. 
+
+D) Apenas pelo crime de direção sem habilitação, pois o delito de embriaguez ao volante só se configura quando ocorre acidente de trânsito com vítima. 
+
+---
+ENUM Questão 
+
+35-De acordo com o Código Penal brasileiro é CORRETO afirmar que:
+
+
+OPTIONS 
+
+A) A tentativa perfeita não admite a desistência voluntária
+
+B) A desistência voluntária e o arrependimento posterior possuem a mesma conseqüência jurídica, afastar a punição por tentativa e responsabilizar o agente pelos atos já praticados
+
+C) A tentativa imperfeita ocorre quando o sujeito, apesar de lançar mão de todos os meios que tinha a seu alcance, não consegue obter o resultado desejado por circunstâncias alheias à sua vontade
+
+D) A tentativa branca ou crime falho ocorre quando o sujeito realiza o ato executório, contudo, não atinge o objeto material do delito
+
+---
+ENUM Questão 
+
+36-Segundo a Lei Antidrogas (Lei 11.343/06), julgue os itens abaixo:
+
+
+I) O indiciado ou acusado que colaborar voluntariamente com a investigação policial e o processo criminal na identificação dos demais co-autores ou partícipes do crime e na recuperação total ou parcial do produto do crime, no caso de condenação, terá a pena reduzida de um terço a dois terços
+
+II) O condenado por associação para fins de tráfico deverá cumprir mais de dois quintos da pena para obtenção do livramento condicional.
+
+III) Aquele que instiga, induz ou auxilia alguém ao uso indevido da droga, assim como, oferece a droga, eventualmente e sem objetivo de lucro, a pessoa de seu relacionamento, para junto consumirem, pode se valer da suspensão condicional do processo prevista na Lei 9.099/95.
+
+IV) O juiz na fixação das penas considerará, com preponderância sobre o previsto no art. 59 do Código Penal, a natureza e a quantidade da substância ou produto, a personalidade e a conduta social do agente.
+
+
+OPTIONS 
+
+A) Todos os itens estão errados
+
+B) Todos os itens estão certos
+
+C) Somente o item III está errado
+
+D) Somente o item II está errado
+
+---
+ENUM Questão 
+
+37- O interrogatório do acusado é compreendido doutrinariamente:
+
+
+OPTIONS 
+
+A) Meio de obter a confissão do acusado
+
+B) Meio de estabelecer o contraditório
+
+C) Meio de defesa
+
+D) Meio de defesa e de prova
+
+---
+ENUM Questão 
+
+
+38-De que meio legal deverá se utilizar o delegado para ouvir testemunha q reside em outro município:
+
+
+OPTIONS 
+
+A) Oficio
+
+B) Telegrama
+
+C) Precatória
+
+D) Rogatória
+
+---
+ENUM Questão 
+
+
+39- A respeito do tema processos em espécie assinale a alternativa q se encontra em conformidade com as recentes alterações introduzidas no CPP:
+
+
+OPTIONS 
+
+A) O procedimento será comum ou especial, o comum será ordinário e sumario e o especial ser sumaríssimo
+
+B) Na hipótese de crime cuja sanção máxima cominada for inferior a 4 anos de pena privativa de liberdade aplica-se procedimento ordinário
+
+C) Nos procedimentos ordinários e comuns oferecidas a queixa ou a denúncia o juiz ao recebê-la ordenara a citação do acusado para oferecer a defesa por escrito em 10 dias.
+
+D) O réu ou seu defensor poderá logo após o interrogatório ou no prazo de 3 dias oferecer alegações escritas e arrolar testemunhas
+
+---
+ENUM Questão 
+
+
+40- As partes possuem o direito de na relação processual insurgirem-se contra decisões judiciais requerendo a sua revisão total ou parcial em instância superior. Para tanto, o CPP enumera diversos recursos objetivando o livre e pleno exercício do direito de ação e de defesa. Nesse contexto assinale a alternativa correta: 
+
+
+OPTIONS 
+
+A) MP poderá desistir de recurso que haja interposto
+
+B) Caberá RSE da decisão, despacho ou sentença que pronunciar ou impronunciar o réu
+
+C) Os embargos de declaração poderão ser opostos no prazo de 48 h contados da publicação do acórdão
+
+D) Contra sentença de impronúncia ou absolvição sumária caberá apelação
+
+---
+ENUM Questão 
+
+
+Empresarial
+
+
+41 - Com base na disciplina jurídica das sociedades anônimas, julgue os seguintes itens.
+
+
+I - As sociedades por ações podem ser classificadas em abertas ou fechadas, considerando-se a participação do Estado em seu capital social.
+
+II - A Comissão de Valores Mobiliários, entidade autárquica em regime especial vinculada ao Ministério da Fazenda, é responsável pela emissão de ações em mercado primário.
+
+III - Ações preferenciais são aquelas que conferem ao seu titular uma vantagem na distribuição dos lucros sociais entre os acionistas e podem, exatamente por isso, ter limitado ou suprimido o direito de voto.
+
+IV - As ações, as debêntures, os bônus de subscrição e as partes beneficiárias, entre outras, são espécies de valores mobiliários emitidos pelas companhias para a captação de recursos.
+
+V - O valor nominal da ação é alcançado com a sua venda no ambiente de bolsa de valores.
+
+Estão certos apenas os itens:
+
+
+OPTIONS 
+
+A) III e IV.
+
+B) I e V.
+
+C) II e III.
+
+D) I, II, IV e V.
+
+---
+ENUM Questão 
+
+42 - A sociedade simples difere, essencialmente, da sociedade empresária por que:
+
+
+OPTIONS 
+
+A) Naquela, a responsabilidade dos sócios é sempre subsidiária, enquanto nesta, é sempre limitada.
+
+B) Aquela não exerce atividade própria de empresário sujeito a registro, ao contrário do que ocorre nesta.
+
+C) Aquela deve constituir-se apenas sob as normas que lhe são próprias, enquanto esta pode constituir-se utilizando-se de diversos tipos.
+
+D) Aquela não exerce atividade econômica nem visa ao lucro, ao contrário desta.
+
+---
+ENUM Questão 
+QUESTÃO 27
+
+43 - Com relação às regras que disciplinam a situação do sócio-quotista da sociedade limitada, assinale a opção correta.
+
+
+OPTIONS 
+
+A) As quotas são bens de livre disposição do sócio, que poderá vendê-las a outro sócio ou a terceiro, independentemente da anuência dos demais sócios.
+
+B) As quotas representam a necessária divisão do capital social em partes iguais, sendo as deliberações consideradas de acordo com o número de quotas de cada sócio.
+
+C) A responsabilidade dos sócios é restrita ao valor de suas quotas, mas todos respondem pela integralização do capital social.
+
+D) As quotas podem ser integralizadas pelos sócios por valores representados em dinheiro, bens ou prestação de serviços, respondendo solidariamente todos os sócios pela exata estimação dessas contribuições.
+
+---
+ENUM Questão 
+
+44 - Assinale a opção correta:
+
+
+OPTIONS 
+
+A) A qualificação de uma sociedade como empresarial só ocorre quando ela exerce atividade própria de empresário sujeito a registro.
+
+B) A sociedade que precipuamente exercer atividade de empresário rural só poderá adotar tipo reservado às sociedades empresárias.
+
+C) A constituição de sociedade para a realização de apenas um negócio determinado é incompatível com a atividade empresarial, pois impede a habitualidade de seu exercício.
+
+D) O conceito de sociedade implica o exercício de atividade econômica, embora nem toda sociedade que realize atividade econômica seja necessariamente considerada empresarial.
+
+---
+ENUM Questão 
+
+45 - Com base na Lei n.º 6.406/1976, que dispõe sobre as sociedades por ações, assinale a opção correta acerca das características jurídicas desse tipo de sociedade empresarial.
+
+
+OPTIONS 
+
+A) Nessas sociedades, apenas acionistas poderão ser simultaneamente titulares de ações e debêntures.
+
+B) As partes beneficiárias compõem o capital social desse tipo de sociedade, sendo permitida a participação nos lucros anuais.
+
+C) As ações, quanto à forma, podem ser classificadas em ordinárias e preferenciais.
+
+D) Os bônus de subscrição conferem direito de crédito contra a companhia, podendo conter garantia real ou flutuante.
+
+---
+ENUM Questão 
+
+
+
+Direito e Processo Civil
+
+
+46 - A audiência de instrução e julgamento (AIJ) é ato passível de ser realizado nos procedimentos ordinário, sumário e no previsto pela Lei n.º 9.099/2005, dos juizados especiais cíveis. Entretanto, a finalidade da AIJ nos juizados não é exatamente a mesma daquela realizada nos procedimentos ordinário e sumário, pois, certos atos que, nos juizados, devem ser realizados nessa audiência, já ocorreram anteriormente nos procedimentos ditos comuns. Nesse sentido,
+
+
+OPTIONS 
+
+A) A prova pericial com o auxílio de assistentes técnicos e diligências, que nos juizados só é admitida na AIJ, nos procedimentos ordinário e sumário realiza-se antes dessa audiência.
+
+B) a conciliação, cuja tentativa pelo juízo ainda é admitida na AIJ do juizado, não mais ocorre na AIJ dos procedimentos ordinário e sumário.
+
+C) a prova testemunhal, que só é admitida na AIJ do juizado, na AIJ dos procedimentos ordinário e sumário só é admitida, respectivamente, na audiência preliminar prevista no art. 331 do Código de Processo Civil (CPC) e na audiência prevista no art. 277 do CPC.
+
+D) A contestação, que nos juizados deve ser apresentada na AIJ, no procedimento ordinário já foi anteriormente apresentada.
+
+---
+ENUM Questão 
+
+47- A respeito da petição inicial e da resposta do réu, assinale a opção correta.
+
+
+OPTIONS 
+
+A) Contra a decisão que indefere total ou parcialmente a petição inicial, o recurso cabível é a apelação. Quando for interposto esse recurso, cabe juízo de retratação da sentença, podendo o juiz modificar sua decisão e determinar a citação do réu.
+
+B) O não-comparecimento do réu ao processo, para praticar uma das modalidades de resposta, gera, de regra, presunção de veracidade dos fatos afirmados pelo autor e exonera o juiz de intimar o réu dos atos processuais praticados. No entanto, esse revel poderá intervir no processo em qualquer fase, recebendo-o no estado em que se encontrar.
+
+C) A reconvenção é cabível em qualquer procedimento, inclusive nas ações dúplices, desde que satisfeitos os pressupostos processuais e as condições da ação. Não obstante a autonomia da reconvenção, o manejo dela exige a sua apresentação em petição escrita, simultaneamente com a contestação.
+
+D) Quando for proposta uma ação em que a pretensão do autor seja daquelas em que a matéria controvertida seja de direito ou, sendo de fato, já existam outras causas idênticas, poderá o juiz julgar liminarmente a lide, rejeitando ou acolhendo o pedido do autor.
+
+---
+ENUM Questão 
+
+48- A respeito das partes e dos procuradores, assinale a opção correta.
+
+
+OPTIONS 
+
+A) Ao réu preso, ainda que tenha sido citado pessoalmente, deve ser nomeado curador especial, que tem a
+
+incumbência de contestar o feito, sendo-lhe vedado manifestar-se contrariamente àquele que representa.
+
+B) No caso de falecimento do procurador do réu, ainda que iniciada a audiência de instrução e julgamento, o juiz deve determinar a suspensão do processo e marcar prazo para que o réu constitua novo mandatário. Findo o prazo, se o réu não cumprir a determinação, o juiz deve determinar o prosseguimento do processo e garantir ao réu curador especial.
+
+C) A alienação da coisa litigiosa, no curso do processo, altera a legitimidade das partes, devendo prosseguir a demanda entre adquirente em substituição ao alienante e a parte contrária originária. A decisão proferida na causa em que atua o substituto processual faz coisa julgada para o substituído.
+
+D) A outorga de procuração para o foro, em geral, habilita o advogado a praticar todos os atos do processo em nome da parte, podendo ele receber e dar quitação, reconhecer a procedência do pedido e firmar qualquer compromisso.
+
+---
+ENUM Questão 
+
+49- Quanto às nulidades processuais, assinale a opção correta.
+
+
+OPTIONS 
+
+A) O ato processual praticado em desconformidade com a norma que disciplina sua produção é inválido, devendo o juiz, de ofício, decretar sua nulidade e determinar sua repetição, ainda que não cause prejuízo à regularidade processual ou às partes.
+
+B) Deve ser decretada a nulidade do processo em que se tenha constatado, afinal, a falta de outorga uxória, ainda que se possa decidir o mérito a favor do cônjuge ausente, visto que todas as nulidades processuais são insanáveis.
+
+C) A nulidade relativa deve ser argüida pela parte interessada em sua decretação, na primeira oportunidade em que lhe couber falar nos autos, depois do ato defeituoso, sob pena de preclusão, isto é, de perda da faculdade processual de promover a anulação.
+
+D) Anulado um ato processual, mesmo que se trate de um ato complexo, todos os atos subseqüentes a ele serão também anulados, ainda que sejam independentes entre si e que a nulidade se refira a apenas uma parte do ato. 
+
+---
+ENUM Questão 
+
+50- Acerca da resposta do réu, assinale a opção correta.
+
+
+OPTIONS 
+
+A) No caso de a incompetência do juízo, absoluta ou relativa, não ser alegada como preliminar na contestação, ocorrerá a chamada prorrogação de competência.
+
+B) Ocorrendo a conexão de ações propostas em separado, o juiz pode, a pedido do réu como preliminar da contestação e, não, de ofício, determinar a reunião das ações para que sejam decididas na mesma sentença.
+
+C) Caso o réu compareça em juízo para apontar a inexistência ou a invalidade da citação e esta não seja acolhida, o juiz deve, no mesmo despacho, determinar nova citação do réu e a reabertura do prazo para resposta, de modo que este deduza o restante da defesa.
+
+D) Em obediência ao princípio da concentração das defesas, o réu deve alegar, na contestação, toda a matéria de defesa, exceto aquelas que devem ser veiculadas através de exceção, ainda que uma somente possa ser acolhida caso outra seja rejeitada 
+
+---
+ENUM Questão 
+
+51 - Em 2004, Thiago, que não tinha herdeiros necessários, lavrou um testamento contemplando como sua herdeira universal Bruna. Em 2006, arrependido, Thiago revogou o testamento de 2004, nomeando como seu herdeiro universal Mauro. Em 2008, Mauro faleceu, deixando uma filha Rita. No mês de julho de 2010, faleceu Thiago. O único parente vivo de Thiago era seu irmão, Saulo. Assinale a alternativa que indique a quem caberá a herança de Thiago.
+
+
+OPTIONS 
+
+A) Saulo.
+
+B) Rita.
+
+C) Bruna.
+
+D) A herança será vacante.
+
+---
+ENUM Questão 
+
+52 - Platão prometeu transferir a propriedade de uma coisa certa, mas antes disso, sem culpa sua, o bem foi deteriorado. Segundo o Código Civil, ao caso de Platão aplica-se o seguinte regime jurídico:
+
+
+OPTIONS 
+
+A) a obrigação fica resolvida, com a devolução de valores eventualmente pagos.
+
+B) a obrigação subsiste, com a entrega da coisa no estado em que se encontra.
+
+C) a obrigação subsiste, com a entrega da coisa no estado em que se encontra e abati mento no preço proporcional à deterioração.
+
+D) a obrigação poderá ser resolvida, com a devolução de valores eventualmente pagos, ou subsisti r, com a entrega da coisa no estado em que se encontra e abati mento no preço proporcional à deterioração, cabendo ao credor a escolha de uma dentre as duas soluções.TÃO 43
+
+---
+ENUM Questão 
+
+53 - Por meio de uma promessa de compra e venda, celebrada por instrumento particular registrada no cartório de Registro de Imóveis e na qual não se pactuou arrependimento, Raul foi residir no imóvel objeto do contrato e, quando quitou o pagamento, deparou-se com a recusa do promitente-vendedor em outorgar-lhe a escritura definitiva do imóvel. Diante do impasse, Raul poderá:
+
+
+OPTIONS 
+
+A) requerer ao juiz a adjudicação do imóvel, a despeito de a promessa de compra e venda ter sido celebrada por instrumento particular.
+
+B) usucapir o imóvel, já que não faria jus à adjudicação compulsória na hipótese.
+
+C) desistir do negócio e pedir o dinheiro de volta.
+
+D) exigir a substituição do imóvel prometi do à venda por outro, muito embora inexistisse previsão expressa a esse respeito no contrato preliminar.
+
+---
+ENUM Questão 
+
+54 - Assinale a opção correta no que se refere aos contratos tipificados no Código Civil brasileiro.
+
+
+OPTIONS 
+
+A) No contrato de doação, são revogáveis por ingratidão as doações puramente remuneratórias e as oneradas com encargo já cumprido.
+
+B) Tanto o contrato de empreitada quanto o de prestação de serviço geram obrigação de resultado.
+
+C) O contrato de compra e venda subordinado à condição de dissolução caso o objeto do contrato não seja do agrado do comprador denomina-se venda a contento, cláusula sempre presumida nos contratos de compra e venda.
+
+D) O contrato estimatório é aleatório e deve ter por objeto coisa móvel.
+
+---
+ENUM Questão 
+
+55 - No que se refere aos institutos da posse e da propriedade, assinale a opção correta.
+
+
+OPTIONS 
+
+A) Ao possuidor de má-fé serão ressarcidas somente as benfeitorias necessárias e úteis, não lhe assistindo o direito de retenção pela importância das benfeitorias necessárias.
+
+B) Caracteriza usucapião a posse, por cinco anos, de coisa móvel, desde que comprovada a boa-fé do possuidor.
+
+C) Aquele que semeia, planta ou edifica em terreno alheio perde, em proveito do proprietário, as sementes, plantas e construções, com direito a indenização se procede de boa-fé.
+
+D) A posse direta, de pessoa que tem a coisa em seu poder, temporariamente, em virtude de direito pessoal, ou real, anula a indireta, de quem aquela foi havida.
+
+---
+ENUM Questão 
+
+Direito e Processo do Trabalho
+
+
+
+56- Camila ajuizou reclamação trabalhista com pedido de pagamento de adicional de periculosidade referente aos 10 últimos meses do contrato de trabalho. Em defesa, a reclamada diz que pagava anteriormente por mera liberalidade. Nesta hipótese:
+
+
+OPTIONS 
+
+A) Indispensável a produção de prova pericial.
+
+B) Dispensável a produção de prova pericial.
+
+C) Será indispensável se Camila requerer o adicional no grau máximo.
+
+D) Será dispensável se Camila requerer o adicional no grau mínimo.
+
+---
+ENUM Questão 
+
+57- Julia, jornalista, foi contratada para exercer as funções típicas de jornalista em uma rede de supermercados. Neste caso, sua jornada de trabalho:
+
+
+OPTIONS 
+
+A) Não deverá exceder de 5 horas.
+
+B) Não deverá exceder de 8 horas.
+
+C) Não deverá exceder de 8 horas, salvo se tiver outro emprego.
+
+D) Não deverá exceder de 5 horas, salvo de tiver outro emprego.
+
+---
+ENUM Questão 
+
+58- Por determinação de seu empregador, Marília entrou de férias no dia 5/9/2011 (segunda-feira), e, recebeu o pagamento das férias com o terço constitucional no dia 9/5/2011 (sexta-feira). Marília,
+
+
+OPTIONS 
+
+A) Tem direito ao pagamento em dobro dos 4 primeiros dias de férias.
+
+B) Tem direito ao pagamento em dobro dos 4 primeiros dias de férias, incluído o terço constitucional.
+
+C) Tem direito ao pagamento em dobro da remuneração de férias, incluído o terço constitucional.
+
+D) Não direito a qualquer outro pagamento das férias.
+
+---
+ENUM Questão 
+
+59- Devido ao mercado favorável, Thiago, contratado para cumprir jornada de seis horas de trabalho, está trabalhando habitualmente duas horas extraordinárias diárias. Nesta hipótese:
+
+
+OPTIONS 
+
+A) Será obrigatório um intervalo intrajornada de 15 (quinze) minutos após a 4ª hora, e outro, de 15 minutos, antes do início da jornada extraordinária.
+
+B) Será obrigatório apenas um intervalo intrajornada de 15 (quinze) minutos.
+
+C) No mínimo de uma hora, obrigando o empregador a remunerar o período para descanso e alimentação não usufruído como parcela indenizatória. 
+
+D) No mínimo de uma hora, obrigando o empregador a remunerar o período para descanso e alimentação não usufruído como extra, acrescido do respectivo adicional.
+
+---
+ENUM Questão 
+
+60- Pedro, gerente de divisão, recebeu do seu empregador um aparelho de telefone "nextel", onde recebia mensagens e chamadas via rádio, mesmo após o término da jornada contratual. Um mês após, solicitou o pagamento de sobreaviso. Diante do requerimento apresentado, o empregador:
+
+
+OPTIONS 
+
+A) Pagará apenas os minutos efetivamente ocupados com a leitura de mensagens e conversas telefônicas, com o adicional de horas extras.
+
+B) Pagará apenas os minutos efetivamente ocupados com a leitura de mensagens e conversas telefônicas, sem o adicional de horas extras.
+
+C) Pagará apenas os minutos efetivamente ocupados com a leitura de mensagens e conversas telefônicas, como sobreaviso.
+
+D) Não pagará qualquer valor, pois o uso do aparelho, por si só, não caracteriza o regime de sobreaviso.
+
+---
+ENUM Questão 
+
+61- Lucas, representante suplente dos empregados, membro de Comissão de Conciliação Prévia, foi suspenso por cinco dias em razão da prática de falta grave passível de demissão por justa causa. Neste caso, seu empregador:
+
+
+OPTIONS 
+
+A) Deverá ajuizar reclamação escrita ou verbal a fim de instaurar inquérito para apuração de falta grave perante uma das Varas do Trabalho, dentro de quinze dias, contados da data da suspensão de Lucas.
+
+B) Deverá ajuizar reclamação escrita a fim de instaurar inquérito para apuração de falta grave perante uma das Varas do Trabalho, dentro de trinta dias, contados da data da suspensão de Lucas.
+
+C) Poderá dispensar Lucas após o término da pena de suspensão aplicada, tendo em vista que o membro suplente de Comissão de Conciliação Prévia não possui estabilidade.
+
+D) Poderá dispensar Lucas imediatamente, tendo em vista que o membro suplente de Comissão de Conciliação Prévia não possui estabilidade.
+
+---
+ENUM Questão 
+
+62- Das decisões finais prolatadas em ações rescisórias:
+
+
+OPTIONS 
+
+A) Não caberá recurso.
+
+B) Caberá mandado de segurança ao Tribunal Superior do Trabalho.
+
+C) Caberá recurso ordinário ao Tribunal Superior do Trabalho.
+
+D) Caberá recurso ordinário ao Tribunal Regional do Trabalho competente.
+
+---
+ENUM Questão 
+
+63- Daniel, advogada de Caroline, pretende ajuizar reclamação trabalhista cujo valor da causa é de R$ 12.000,00. Neste caso, em regra,
+
+
+OPTIONS 
+
+A) Daniel deverá arrolar previamente até duas testemunhas na petição inicial, sob pena de preclusão.
+
+B) Na data da audiência, Caroline deverá trazer até três testemunhas, independentemente de intimação.
+
+C) O pedido deverá ser certo e determinado, indicando o valor de R$ 12.000,00.
+
+D) Daniel poderá requerer a citação por edital se a empresa ré, comprovadamente, possuir endereço incerto.
+
+---
+ENUM Questão 
+
+64- Assinale a alternativa correta:
+
+
+OPTIONS 
+
+A) É válido o instrumento de mandato com prazo determinado que contém cláusula estabelecendo a prevalência dos poderes para atuar até o final da demanda.
+
+B) É admissível em instância recursal, o oferecimento tardio de procuração, ainda que mediante protesto por posterior juntada, já que a interposição de recurso não pode ser reputada ato urgente.
+
+C) Nas Reclamatórias Plúrimas os empregados não poderão fazer-se representar pelo Sindicato de sua categoria, tendo em vista que não se trata de dissídio coletivo, mas sim de dissídio individual com diversos reclamantes.
+
+D) Não configura irregularidade de representação o fato de o substabelecimento ser anterior à outorga passada ao substabelecente, tratando-se de mera irregularidade formal.
+
+---
+ENUM Questão 
+
+65- O jus postulandi das partes, estabelecido na Consolidação das Leis do Trabalho,
+
+
+OPTIONS 
+
+A) Limita-se às Varas do Trabalho, alcançando ação rescisória de sua competência.
+
+B) Limita-se às Varas do Trabalho, alcançando os mandados de segurança de sua competência. 
+
+C) É ilimitado, não havendo na lei, em Súmulas ou Orientações Jurisprudenciais qualquer limitação, pois trata-se de direito assegurado pela Constituição Federal.
+
+D) Limita-se às Varas do Trabalho e aos Tribunais Regionais do Trabalho, não alcançando os recursos de competência do Tribunal Superior do Trabalho.
+
+---
+ENUM Questão 
+
+Direito Tributário
+
+
+66- Quanto ao instituto da imputação, assinale a alternativa correta de acordo com o entendimento atual do STJ:
+
+
+OPTIONS 
+
+A) Em dívida tributária composta por capital e juros, o pagamento imputar-se-á primeiro no capital e, depois, nos juros vencidos, salvo se a lei dispuser o contrário.
+
+B) Em dívida composta por capital e juros, o pagamento imputar-se-á primeiro nos juros vencidos e, depois, no capital, não importando a vontade das partes.
+
+C) Às compensações tributárias aplica-se subsidiariamente a regra de imputação estipulada no Código Civil, tendo em vista a ausência de lei tributária específica sobre a matéria.
+
+D) Às compensações tributárias não se aplica a regra de imputação de pagamentos estipulada no Código Civil, ainda que não haja lei tributária específica sobre a matéria. 
+
+---
+ENUM Questão 
+
+
+67- À luz do posicionamento consolidado pelo STF, assinale a opção que contém conduta inconstitucional da Fazenda Pública:
+
+
+OPTIONS 
+
+A) Exigência de depósito prévio como requisito de admissibilidade de ação judicial na qual se pretenda discutir exigibilidade de crédito tributário.
+
+B) Recusa de bens ilíquidos oferecidos pelo contribuinte em garantia de execução fiscal.
+
+C) Pedido de substituição da penhora em execução fiscal quando o contribuinte comprovadamente não detém capacidade econômica.
+
+D) Lançamento de débito fiscal com exigibilidade suspensa a fim de prevenir a decadência.
+
+---
+ENUM Questão 
+
+
+68- Não se incluem na base de cálculo do ICMS:
+
+
+OPTIONS 
+
+A) Prestação de serviço de transporte intermunicipal.
+
+B) Vendas de mercadorias a não contribuinte.
+
+C) Descontos incondicionais.
+
+D) Entrada de mercadoria importada do exterior.
+
+---
+ENUM Questão 
+
+
+69-Assinale a alternativa correta quanto aos entendimentos sumulados pelos Tribunais Superiores:
+
+
+OPTIONS 
+
+A) O STF entende ser constitucional a incidência do ISS sobre operações de locação de bens móveis.
+
+B) O STF entende ser constitucional a incidência do ISS sobre operações de locação de bens móveis, desde que a receita delas decorrentes não seja destinada a instituições em fins lucrativos.
+
+C) O STF entende ser inconstitucional a incidência do ISS sobre operações de locação de bens móveis; todavia, a aplicação do referido posicionamento não é obrigatória pelos tribunais ordinários.
+
+D) O STF entende ser inconstitucional a incidência do ISS sobre operações de locação de bens móveis, sendo que o referido posicionamento deve obrigatoriamente ser seguido por todos os tribunais que julgarem a matéria. 
+
+---
+ENUM Questão 
+
+
+70- Quanto às imunidades tributárias, indique a alternativa incorreta conforme entendimento pacífico do STF:
+
+
+OPTIONS 
+
+A) Quando alugado a terceiros, o imóvel pertencente às instituições de assistência social sem fins lucrativos não perde a imunidade ao IPTU, ainda que o valor dos aluguéis seja aplicado nas atividades essenciais destas entidades.
+
+B) Quando alugado a terceiros, o imóvel pertencente às instituições de assistência social sem fins lucrativos perde a imunidade ao IPTU, ainda que o valor dos aluguéis seja aplicado nas atividades essenciais destas entidades.
+
+C) Quando destinado a uso próprio, o imóvel pertencente às instituições de assistência social sem fins lucrativos tem imunidade em relação ao IPTU.
+
+D) Nenhuma das alternativas acima.
+
+---
+ENUM Questão 
+

--- a/simulated/raw/2011-5.txt
+++ b/simulated/raw/2011-5.txt
@@ -1,540 +1,1205 @@
-                                      
-                                Administrativo
+
+Administrativo
+
 
 1. (FGV - 2010) O atributo pelo qual atos administrativos se impõem a terceiros, ainda que de forma contrária a sua concordância, é denominado: 
 
-A. Competência. 
-B. Veracidade. 
-C. Vinculação. 
-D. Imperatividade. 
- 
+
+OPTIONS 
+
+A) Competência. 
+
+B) Veracidade. 
+
+C) Vinculação. 
+
+D) Imperatividade. 
+
+---
+ENUM Questão 
+
 2. (OAB/Exame Unificado - 2009.1) Assinale a opção correta acerca dos bens públicos. 
 
-A. Consideram-se privados os bens pertencentes às pessoas jurídicas de direito público aos quais a lei tenha dado estrutura de direito privado. 
-B. Considera-se bem público de uso comum o bem público imóvel onde funcione repartição pública. 
-C. Depende de prévia aprovação do Congresso Nacional a alienação ou cessão de terras públicas, de qualquer tamanho, incluindo-se as destinadas à reforma agrária. 
-D. Pode ser autorizada por meio de permissão de uso a utilização, a título precário, de bens públicos imóveis federais para a realização de eventos de curta duração, de natureza recreativa, esportiva, cultural, religiosa ou educacional. 
+
+OPTIONS 
+
+A) Consideram-se privados os bens pertencentes às pessoas jurídicas de direito público aos quais a lei tenha dado estrutura de direito privado. 
+
+B) Considera-se bem público de uso comum o bem público imóvel onde funcione repartição pública. 
+
+C) Depende de prévia aprovação do Congresso Nacional a alienação ou cessão de terras públicas, de qualquer tamanho, incluindo-se as destinadas à reforma agrária. 
+
+D) Pode ser autorizada por meio de permissão de uso a utilização, a título precário, de bens públicos imóveis federais para a realização de eventos de curta duração, de natureza recreativa, esportiva, cultural, religiosa ou educacional. 
+
+---
+ENUM Questão 
 
 3. (OAB/Exame Unificado - 2008.3) Referentemente aos contratos administrativos, assinale a opção correta. 
 
-A. A presença da administração pública na relação contratual é suficiente para se qualificarem aven - ças no contrato administrativo. 
-B. O principio da continuidade do serviço público impede que o contratado suspenda, sob a alega - ção de falta de pagamento, o serviço que presta à administração pública. 
-C. As cláusulas exorbitantes possibilitam à adminis - tração pública alterar unilateralmente o contrato administrativo, exceto no que se refere à manu - tenção do equilíbrio econômico-financeiro. 
-D. A modificação da finalidade da empresa con - tratada pela administração para prestação de serviços implica automática rescisão do contrato administrativo. 
+
+OPTIONS 
+
+A) A presença da administração pública na relação contratual é suficiente para se qualificarem aven - ças no contrato administrativo. 
+
+B) O principio da continuidade do serviço público impede que o contratado suspenda, sob a alega - ção de falta de pagamento, o serviço que presta à administração pública. 
+
+C) As cláusulas exorbitantes possibilitam à adminis - tração pública alterar unilateralmente o contrato administrativo, exceto no que se refere à manu - tenção do equilíbrio econômico-financeiro. 
+
+D) A modificação da finalidade da empresa con - tratada pela administração para prestação de serviços implica automática rescisão do contrato administrativo. 
+
+---
+ENUM Questão 
 
 4. (OAB/Exame Unificado - 2008.3) No que diz respeito à improbidade administrativa, julgue os itens a seguir. 
 
+
 I. De acordo com a lei, a ação de improbidade não pode ser cumulada com pedido de danos morais. 
+
 II. O juiz deve, antes de determinar a citação da ação de improbidade, proceder à notificação prévia do acusado. 
+
 III. O prazo prescricional de ato de improbidade de governador começa a fluir da data em que tenha sido praticado o ato. 
+
 IV. A Lei de Improbidade Administrativa não prevê a gradação das penas que prescreve, não sendo admitida, em consequência, a aplicação da proporcionalidade da pena. 
+
 V. Na avaliação da improbidade por dano ao erário, o juiz deve analisar o elemento subjetivo da conduta do agente. 
+
 
 Estão certos apenas os itens: 
 
-A. I e III. 
-B. I e V. 
-C. II e IV. 
-D. II e V. 
+
+OPTIONS 
+
+A) I e III. 
+
+B) I e V. 
+
+C) II e IV. 
+
+D) II e V. 
+
+---
+ENUM Questão 
 
 5. (OAB/Exame Unificado - 2008.3) Assinale a opção correta acerca de desapropriação. 
-A. A desapropriação indireta, forma legítima de inter - venção na propriedade, é realizada por entidade da administração indireta. 
-B. OS bens públicos não podem ser desapropriados. 
-C. Em caso de desapropriação por interesse social para fim de reforma agrária, deve haver indeni - zação, necessariamente em dinheiro, das benfei - torias úteis e das necessárias. 
-D. A desapropriação de imóveis urbanos pode ser feita mediante prévia e justa indenização, permi - tindo-se à administração, caso haja autorização legislativa do Senado Federal, pagá-la com títulos da divida pública. 
+
+OPTIONS 
+
+A) A desapropriação indireta, forma legítima de inter - venção na propriedade, é realizada por entidade da administração indireta. 
+
+B) OS bens públicos não podem ser desapropriados. 
+
+C) Em caso de desapropriação por interesse social para fim de reforma agrária, deve haver indeni - zação, necessariamente em dinheiro, das benfei - torias úteis e das necessárias. 
+
+D) A desapropriação de imóveis urbanos pode ser feita mediante prévia e justa indenização, permi - tindo-se à administração, caso haja autorização legislativa do Senado Federal, pagá-la com títulos da divida pública. 
+
+---
+ENUM Questão 
 
 6. (FGV - 2008) Assinale a alternativa correta. 
- 
-A. O principio da oralidade é o principio diferencial do pregão em relação às modalidades clássicas de licitação. 
-B. Na inexigibilidade de licitação, esta é material - mente possível, mas, em regra, inconveniente. 
-C. Tomada de Preço é a modalidade de licitação adequada a contratações de grande vulto; apresenta maior rigor formal em seu procedi - mento, se comparada às outras modalidades licitatórias. 
-D. Os bens imóveis da Administração Pública cuja aquisição haja derivado de procedimentos judi - ciais ou de dação em pagamento poderão ser alienados por licitação, sob as modalidades de convite ou leilão. 
+
+
+OPTIONS 
+
+A) O principio da oralidade é o principio diferencial do pregão em relação às modalidades clássicas de licitação. 
+
+B) Na inexigibilidade de licitação, esta é material - mente possível, mas, em regra, inconveniente. 
+
+C) Tomada de Preço é a modalidade de licitação adequada a contratações de grande vulto; apresenta maior rigor formal em seu procedi - mento, se comparada às outras modalidades licitatórias. 
+
+D) Os bens imóveis da Administração Pública cuja aquisição haja derivado de procedimentos judi - ciais ou de dação em pagamento poderão ser alienados por licitação, sob as modalidades de convite ou leilão. 
+
+---
+ENUM Questão 
 
 7. (OAB/Exame Unificado - 2007.2) Acerca dos órgãos públi - cos, assinale a opção correta. 
 
-A. É correto, do ponto de vista da natureza jurídica do órgão, afirmar que "João propôs uma ação de rito ordinário contra a receita federal". 
-B. Alguns órgãos públicos têm capacidade proces - sual, já que são titulares de direitos subjetivos próprios a serem defendidos. 
-C. A teoria que melhor explica a relação existente entre o servidor público e a pessoa juridica do Estado é a teoria da representação, cuja caracte - rística principal consiste no princípio da imputação volitiva. Assim, a vontade do órgão público é impu - tada à pessoa jurídica a cuja estrutura pertence, já que aquele estaria agindo em seu nome. 
-D. A organização da administração pública direta, no que se refere à estruturação dos órgãos e competência, é matéria reservada á lei. 
+
+OPTIONS 
+
+A) É correto, do ponto de vista da natureza jurídica do órgão, afirmar que "João propôs uma ação de rito ordinário contra a receita federal". 
+
+B) Alguns órgãos públicos têm capacidade proces - sual, já que são titulares de direitos subjetivos próprios a serem defendidos. 
+
+C) A teoria que melhor explica a relação existente entre o servidor público e a pessoa juridica do Estado é a teoria da representação, cuja caracte - rística principal consiste no princípio da imputação volitiva. Assim, a vontade do órgão público é impu - tada à pessoa jurídica a cuja estrutura pertence, já que aquele estaria agindo em seu nome. 
+
+D) A organização da administração pública direta, no que se refere à estruturação dos órgãos e competência, é matéria reservada á lei. 
+
+---
+ENUM Questão 
 
 8. (OAB/Exame Unificado - 2007.3) Assinale a opção correta acerca dos princípios da administração pública. 
 
-A. O principio da eficiência não constava expres - samente do texto original da CF, tendo sido inserido posteriormente, por meio de emenda constitucional. 
-B. O princípio da motivação determina que os moti - vos do ato praticado devam ser determinados pelo mesmo órgão que tenha tomado a decisão. 
-C. Embora seja consagrado pela jurisprudência e pela doutrina, o principio da impessoalidade não foi consagrado expressamente na CF. 
-D. Em virtude do princípio da legalidade, a adminis - tração pública somente pode impor obrigações em virtude de lei; direitos, por sua vez, podem ser concedidos por atos administrativos. 
+
+OPTIONS 
+
+A) O principio da eficiência não constava expres - samente do texto original da CF, tendo sido inserido posteriormente, por meio de emenda constitucional. 
+
+B) O princípio da motivação determina que os moti - vos do ato praticado devam ser determinados pelo mesmo órgão que tenha tomado a decisão. 
+
+C) Embora seja consagrado pela jurisprudência e pela doutrina, o principio da impessoalidade não foi consagrado expressamente na CF. 
+
+D) Em virtude do princípio da legalidade, a adminis - tração pública somente pode impor obrigações em virtude de lei; direitos, por sua vez, podem ser concedidos por atos administrativos. 
+
+---
+ENUM Questão 
 
 9. (OAB/Exame Unificado - 2008.2) Assinale a opção correta com relação às normas que regulam o processo administrativo no âmbito da administração pública federal. 
 
-A. As normas que regulam o processo administra - tivo no âmbito da administração pública federal aplicam-se apenas à administração pública direta. 
-B. As normas que regulam o processo administrativo no âmbito da administração pública federal são aplicáveis apenas ao Poder Executivo. 
-C. O administrado tem o direito de ter ciência da tramitação dos processos administrativos em que tenha a condição de interessado bem como de ter vista dos autos, obter cópias de documentos neles contidos e conhecer as decisões proferidas. 
-D. O processo administrativo tem seu início sempre por iniciativa da própria administração pública. 
+
+OPTIONS 
+
+A) As normas que regulam o processo administra - tivo no âmbito da administração pública federal aplicam-se apenas à administração pública direta. 
+
+B) As normas que regulam o processo administrativo no âmbito da administração pública federal são aplicáveis apenas ao Poder Executivo. 
+
+C) O administrado tem o direito de ter ciência da tramitação dos processos administrativos em que tenha a condição de interessado bem como de ter vista dos autos, obter cópias de documentos neles contidos e conhecer as decisões proferidas. 
+
+D) O processo administrativo tem seu início sempre por iniciativa da própria administração pública. 
+
+---
+ENUM Questão 
 
 
 10. (OAB/Exame Unificado - 2007.3) Recente decisão do STF entendeu que a garantia constitucional de respon - sabilidade objetiva de pessoa privada que preste serviço público volta-se apenas ao usuário desse serviço público. De acordo com esse entendimento, não corresponderiam a caso de responsabilidade objetiva danos causados a proprietário 
 
-A. De restaurante, em decorrência de suspensão por 24 horas do fornecimento de energia elétrica. 
-B. De veiculo que, em decorrência de buracos em uma estrada privatizada, tenha sofrido acidente com perda parcial do veiculo. 
-C. de veiculo abalroado por ônibus de empresa de transporte coletivo. 
-D. De hotel, por suspensão, sem motivo, do serviço de distribuição de gás canalizado. 
+
+OPTIONS 
+
+A) De restaurante, em decorrência de suspensão por 24 horas do fornecimento de energia elétrica. 
+
+B) De veiculo que, em decorrência de buracos em uma estrada privatizada, tenha sofrido acidente com perda parcial do veiculo. 
+
+C) de veiculo abalroado por ônibus de empresa de transporte coletivo. 
+
+D) De hotel, por suspensão, sem motivo, do serviço de distribuição de gás canalizado. 
+
+---
+ENUM Questão 
 
 
-                                Constitucional
-                                       
+Constitucional
+
+
 11. Sobre a nacionalidade brasileira, é CORRETO afirmar:
 
-A. Qualquer cargo eletivo do país pode ser ocupado por brasileiro naturalizado, como é o caso do Vice Presidente da República.
-B. A naturalização extraordinária será concedida ao originário de país de língua portuguesa após a comprovação de residência por um ano no país e idoneidade moral.
-C. As hipóteses de aquisição de nacionalidade derivada estão taxativamente previstas na Constituição Federal e não podem ser ampliadas por legislação ordinária.
-D. Os nascidos no estrangeiro entre 7 de junho de 1994 e a data da promulgação da Emenda Constitucional 54/07, filhos de pai brasileiro ou mãe brasileira, poderão ser registrados em repartição diplomática ou consular brasileira competente ou em ofício de registro, se vierem a residir na República Federativa do Brasil.
+
+OPTIONS 
+
+A) Qualquer cargo eletivo do país pode ser ocupado por brasileiro naturalizado, como é o caso do Vice Presidente da República.
+
+B) A naturalização extraordinária será concedida ao originário de país de língua portuguesa após a comprovação de residência por um ano no país e idoneidade moral.
+
+C) As hipóteses de aquisição de nacionalidade derivada estão taxativamente previstas na Constituição Federal e não podem ser ampliadas por legislação ordinária.
+
+D) Os nascidos no estrangeiro entre 7 de junho de 1994 e a data da promulgação da Emenda Constitucional 54/07, filhos de pai brasileiro ou mãe brasileira, poderão ser registrados em repartição diplomática ou consular brasileira competente ou em ofício de registro, se vierem a residir na República Federativa do Brasil.
+
+---
+ENUM Questão 
 
 12. Sobre a teoria geral da Constituição, assinale a alternativa correta:
 
-A. Podemos dizer que as Constituições não escritas são desprovidas de documentos escritos reconhecidos como Constituição.
-B. As normas constitucionais de eficácia limitada não produzem nenhum efeito jurídico.
-C. As Constituições dogmáticas estão associadas, via de regra, às Constituições escritas.
-D. Quanto ao modo de elaboração a Constituição de 1988 é histórica, tendo em vista que foi fruto das manifestações contra a ditadura que a antecedeu.
+
+OPTIONS 
+
+A) Podemos dizer que as Constituições não escritas são desprovidas de documentos escritos reconhecidos como Constituição.
+
+B) As normas constitucionais de eficácia limitada não produzem nenhum efeito jurídico.
+
+C) As Constituições dogmáticas estão associadas, via de regra, às Constituições escritas.
+
+D) Quanto ao modo de elaboração a Constituição de 1988 é histórica, tendo em vista que foi fruto das manifestações contra a ditadura que a antecedeu.
+
+---
+ENUM Questão 
 
 13. "Art. 215. O Estado garantirá a todos o pleno exercício dos direitos culturais e acesso às fontes da cultura nacional, e apoiará e incentivará a valorização e a difusão das manifestações culturais". Podemos dizer que o artigo reproduzido indica que a nossa Constituição é: 
 
-A. Outorgada
-B. Histórica
-C. Promulgada
-D. Dirigente
+
+OPTIONS 
+
+A) Outorgada
+
+B) Histórica
+
+C) Promulgada
+
+D) Dirigente
+
+---
+ENUM Questão 
 
 14. Vários Deputados, em número constitucional suficiente, apresentam proposta de Emenda Constitucional visando aumentar a duração da licença à gestante, sem prejuízo do emprego e do salário, para cento e oitenta dias. Sobre a referida proposta, assinale a alternativa correta:
 
-A. A proposição pode ser aprovada ou rejeitada, segundo a vontade dos legisladores;
-B. Tal medida só pode ser proposta pelas Assembléias Legislativas;
-C. Não pode ser objeto de deliberação por expressa disposição constitucional;
-D. Tal proposição necessitará da participação do Presidente da República por meio da sanção ou veto.
+
+OPTIONS 
+
+A) A proposição pode ser aprovada ou rejeitada, segundo a vontade dos legisladores;
+
+B) Tal medida só pode ser proposta pelas Assembléias Legislativas;
+
+C) Não pode ser objeto de deliberação por expressa disposição constitucional;
+
+D) Tal proposição necessitará da participação do Presidente da República por meio da sanção ou veto.
+
+---
+ENUM Questão 
 
 15. Sobre os direitos fundamentais, assinale a alternativa correta:
 
-A. Os direitos fundamentais se aplicam às relações Estado-indivíduo e indivíduo-indivíduo também.
-B. Os direitos de 2ª geração são os direitos de manipulação genética, relacionados à biotecnologia e aos avanços tecnológicos.
-C. A 4ª dimensão é caracterizada pela exigência dos indivíduos ao Estado para a implementação de políticas públicas;
-D. Os direitos fundamentais são inexigíveis, imprescritíveis e inalienáveis. 
+
+OPTIONS 
+
+A) Os direitos fundamentais se aplicam às relações Estado-indivíduo e indivíduo-indivíduo também.
+
+B) Os direitos de 2ª geração são os direitos de manipulação genética, relacionados à biotecnologia e aos avanços tecnológicos.
+
+C) A 4ª dimensão é caracterizada pela exigência dos indivíduos ao Estado para a implementação de políticas públicas;
+
+D) Os direitos fundamentais são inexigíveis, imprescritíveis e inalienáveis. 
+
+---
+ENUM Questão 
 
 16. Sabe-se que a Constituição em vigor prevê que matéria geral sobre direito tributário deve ser tratada por meio de lei complementar. Sabendo que o Código Tributário Nacional (CTN) foi editado antes da Constituição de 1988, sob a forma de lei ordinária, é possível afirmar que as normas do CTN que regulam limitações constitucionais ao poder de tributar:
 
-A. Devem ser consideradas revogadas com o advento da nova Constituição.
-B. Devem ser consideradas formalmente inconstitucionais e, por isso, insuscetíveis de produzir efeitos, pelo menos a partir da Constituição de 1988.
-C. Continuam a produzir efeitos na vigência da nova Carta, por força do mecanismo da recepção.
-D. Devem ser consideradas repristinadas, podendo produzir efeitos parciais.
+
+OPTIONS 
+
+A) Devem ser consideradas revogadas com o advento da nova Constituição.
+
+B) Devem ser consideradas formalmente inconstitucionais e, por isso, insuscetíveis de produzir efeitos, pelo menos a partir da Constituição de 1988.
+
+C) Continuam a produzir efeitos na vigência da nova Carta, por força do mecanismo da recepção.
+
+D) Devem ser consideradas repristinadas, podendo produzir efeitos parciais.
+
+---
+ENUM Questão 
 
 17. Sobre o Poder Executivo brasileiro, assinale a opção correta.
 
-A. Os ministros do Supremo Tribunal Federal podem ser chamados a suceder o presidente, por ordem de antiguidade;
-B. A lista de convocação de autoridades tanto no caso de impedimento quanto no de vacância obedece à mesma ordem.
-C. Por crime comum o presidente da República é julgado pelo STF e por crime de responsabilidade pelo Senado Federal. Em ambos os casos a Câmara dos Deputados deverá realizar o juízo de admissibilidade quanto à acusação.
-D. Governadores e Prefeitos gozam das mesmas imunidades do presidente da República;
+
+OPTIONS 
+
+A) Os ministros do Supremo Tribunal Federal podem ser chamados a suceder o presidente, por ordem de antiguidade;
+
+B) A lista de convocação de autoridades tanto no caso de impedimento quanto no de vacância obedece à mesma ordem.
+
+C) Por crime comum o presidente da República é julgado pelo STF e por crime de responsabilidade pelo Senado Federal. Em ambos os casos a Câmara dos Deputados deverá realizar o juízo de admissibilidade quanto à acusação.
+
+D) Governadores e Prefeitos gozam das mesmas imunidades do presidente da República;
+
+---
+ENUM Questão 
 
 
 18. Sobre o controle de constitucionalidade das leis no Brasil, responda  ao quesito correto:
 
-   I- O controle de constitucionalidade pode ser difuso ou concentrado.
-   II- Não há inconstitucionalidade por ação, somente por omissão.
-   III- A supremacia constitucional é um dos princípios de destaque do controle de constitucionalidade
-   IV-  Todas as normas constitucionais gozam de presunção absoluta de constitucionalidade
+
+I- O controle de constitucionalidade pode ser difuso ou concentrado.
+
+II- Não há inconstitucionalidade por ação, somente por omissão.
+
+III- A supremacia constitucional é um dos princípios de destaque do controle de constitucionalidade
+
+IV-  Todas as normas constitucionais gozam de presunção absoluta de constitucionalidade
+
 
 Estão corretas:
 
-A. I e II;
-B. I e III;
-C. I , III e IV;
-D. II e IV;
+
+OPTIONS 
+
+A) I e II;
+
+B) I e III;
+
+C) I , III e IV;
+
+D) II e IV;
+
+---
+ENUM Questão 
 
 19. Medida Provisória que alterasse o procedimento sumário previsto no Código de
+
 Processo Civil e que fosse prorrogada por mais 60 (sessenta) dias, durante a
+
 vigência de estado de sítio,
 
-A. Não deveria ser convertida em lei, porque a prorrogação só é admitida por mais 30 (trinta) dias, prorrogáveis uma vez por igual período;
-B. Não deveria ser convertida em lei, porque não pode dispor sobre direito processual civil;
-C. Não deveria ser convertida em lei, porque não poderia ser prorrogada sob a vigência de estado de sítio;
-D. Deveria ser convertida em lei, porque foi produzida nos termos da Constituição Federal.
+
+OPTIONS 
+
+A) Não deveria ser convertida em lei, porque a prorrogação só é admitida por mais 30 (trinta) dias, prorrogáveis uma vez por igual período;
+
+B) Não deveria ser convertida em lei, porque não pode dispor sobre direito processual civil;
+
+C) Não deveria ser convertida em lei, porque não poderia ser prorrogada sob a vigência de estado de sítio;
+
+D) Deveria ser convertida em lei, porque foi produzida nos termos da Constituição Federal.
+
+---
+ENUM Questão 
 
 20. Determinado projeto de lei de iniciativa popular é primeiramente discutido, votado e aprovado sem emendas no Senado Federal, seguindo para a Câmara dos Deputados, onde também é discutido, votado e aprovado sem emendas, sendo então enviado ao presidente da República, para sancioná-lo ou vetá-lo no prazo de 15 dias úteis, contados da datas do recebimento. Todavia, o Presidente da República resta silente, sendo, pois, o projeto considerado vetado. Considerando exclusivamente os aspectos mencionados, nessa situação foram: 
 
-A. Desrespeitadas apenas as regras constitucionais quanto ao prazo para sanção ou veto e quanto aos efeitos do silêncio do Presidente da República; 
-B. Desrespeitadas apenas as regras constitucionais quanto à ordem de votação entre as casas legislativas e quanto aos efeitos do silêncio do Presidente da República;
-C. Desrespeitadas as regras constitucionais quanto à ordem de votação entre as casas legislativas, quanto ao prazo para sanção ou veto e quanto aos efeitos do silêncio do Presidente da República;
-D. Desrespeitadas todas as regras constitucionais quanto ao processo legislativo.
+
+OPTIONS 
+
+A) Desrespeitadas apenas as regras constitucionais quanto ao prazo para sanção ou veto e quanto aos efeitos do silêncio do Presidente da República; 
+
+B) Desrespeitadas apenas as regras constitucionais quanto à ordem de votação entre as casas legislativas e quanto aos efeitos do silêncio do Presidente da República;
+
+C) Desrespeitadas as regras constitucionais quanto à ordem de votação entre as casas legislativas, quanto ao prazo para sanção ou veto e quanto aos efeitos do silêncio do Presidente da República;
+
+D) Desrespeitadas todas as regras constitucionais quanto ao processo legislativo.
+
+---
+ENUM Questão 
 
 
-                                  Deontologia
+Deontologia
+
 
 21  -  O advogado Pedro Freitas, regularmente inscrito na OAB/RJ, foi eleito em assembléia de acionistas e empossado Presidente do Banco Real. Como fica a situação desse advogado junto à OAB/RJ e quanto ao exercício da Advocacia? 
-      A.  O advogado terá sua inscrição na OAB/RJ cancelada e, conseqüentemente não poderá mais exercer a advocacia; 
-      B.  O advogado será licenciado pela OAB/RJ e, por conseqüência, não poderá exercer a advocacia durante o tempo em que for Presidente do Banco Real; 
-      C. O advogado continuará inscrito na OAB/RJ e exercendo a advocacia, ficando, porém, impedido de advogar contra o Banco Real; 
-      D. O advogado continuará inscrito na OAB-RJ e exercendo a advocacia normalmente, sem qualquer restrição, por se tratar de Banco privado. 
+
+OPTIONS 
+
+A)  O advogado terá sua inscrição na OAB/RJ cancelada e, conseqüentemente não poderá mais exercer a advocacia; 
+
+B)  O advogado será licenciado pela OAB/RJ e, por conseqüência, não poderá exercer a advocacia durante o tempo em que for Presidente do Banco Real; 
+
+C) O advogado continuará inscrito na OAB/RJ e exercendo a advocacia, ficando, porém, impedido de advogar contra o Banco Real; 
+
+D) O advogado continuará inscrito na OAB-RJ e exercendo a advocacia normalmente, sem qualquer restrição, por se tratar de Banco privado. 
+
+---
+ENUM Questão 
 22  -  Infringe disposição expressa do Código de Ética e Disciplina da OAB o advogado que: 
-   A. Renuncia ao mandato outorgado por um cliente, mesmo contra a vontade deste; 
-   B. Recusa-se a atuar numa causa cível, quando for imposição do cliente que o advogado trabalhe com outro advogado indicado pelo cliente; 
-   C. Publica anuncio em jornal de grande circulação, informando, além do nome e número de inscrição na OAB, ser ele integrante do Instituto de Estudos Criminais do Estado do Rio de Janeiro  -  Iecerj;
-   D. Faz emitir uma nota promissória ao cliente para garantia do pagamento de seus honorários. 
+
+OPTIONS 
+
+A) Renuncia ao mandato outorgado por um cliente, mesmo contra a vontade deste; 
+
+B) Recusa-se a atuar numa causa cível, quando for imposição do cliente que o advogado trabalhe com outro advogado indicado pelo cliente; 
+
+C) Publica anuncio em jornal de grande circulação, informando, além do nome e número de inscrição na OAB, ser ele integrante do Instituto de Estudos Criminais do Estado do Rio de Janeiro  -  Iecerj;
+
+D) Faz emitir uma nota promissória ao cliente para garantia do pagamento de seus honorários. 
+
+---
+ENUM Questão 
 23 - Em razão de acidente de motocicletas provocado por Carlos da Silva, este pagou a João Rocha, em composição amigável, a quantia de R$ 10.000 (dez mil reais) pelos danos materiais causados na motocicleta de João Rocha, que deu quitação do que lhe era devido. Passados 5 (cinco) meses, João Rocha procurou o advogado Caio das Neves e este, mesmo tendo ciência daquele acordo, foi contratado por João Rocha e ingressou em juízo com uma Ação de Ressarcimento de Danos por acidente de veículos contra Carlos da Silva, pleiteando a indenização de R$ 10.000,00 (dez mil reais) pelos danos materiais causados no veículo de João Rocha. Marque a alternativa correta: 
-   A. O advogado cometeu patrocínio simultâneo e fraude processual; 
-   B. O advogado praticou uma lide temerária; 
-   C. O advogado cometeu uma inépcia profissional; 
-   D. O advogado cometeu tergiversação. 
+
+OPTIONS 
+
+A) O advogado cometeu patrocínio simultâneo e fraude processual; 
+
+B) O advogado praticou uma lide temerária; 
+
+C) O advogado cometeu uma inépcia profissional; 
+
+D) O advogado cometeu tergiversação. 
+
+---
+ENUM Questão 
 24  -  Marque a opção que indique em que casos uma pessoa que não é advogada pode ingressar em juízo pessoalmente, isto é, sem se fazer representar por um advogado? 
-   A. Apenas na impetração de Habeas Corpus e no Juizado Especial Cível até 20 (vinte) salários mínimos; 
-   B. Na impetração de Habeas Corpus, na Justiça do Trabalho (1ª Instância), no Juizado Especial Cível (até 20 salários mínimos) e no Mandado de Segurança; 
-   C. Na impetração de Habeas Corpus, no Juizado Especial Cível até 20(vinte) salários mínimos, na Justiça do Trabalho (1ª Instância) e no Juizado de Paz (embora este último não seja um órgão jurisdicional); 
-   D. Na impetração de Habeas Corpus, no Juizado Especial Cível até 20 (vinte) salários mínimos, na Justiça do Trabalho (1ª Instância), no Juizado de Paz e na Ação Popular. 
+
+OPTIONS 
+
+A) Apenas na impetração de Habeas Corpus e no Juizado Especial Cível até 20 (vinte) salários mínimos; 
+
+B) Na impetração de Habeas Corpus, na Justiça do Trabalho (1ª Instância), no Juizado Especial Cível (até 20 salários mínimos) e no Mandado de Segurança; 
+
+C) Na impetração de Habeas Corpus, no Juizado Especial Cível até 20(vinte) salários mínimos, na Justiça do Trabalho (1ª Instância) e no Juizado de Paz (embora este último não seja um órgão jurisdicional); 
+
+D) Na impetração de Habeas Corpus, no Juizado Especial Cível até 20 (vinte) salários mínimos, na Justiça do Trabalho (1ª Instância), no Juizado de Paz e na Ação Popular. 
+
+---
+ENUM Questão 
 25  -  O advogado Jorge Dias, que tem domicílio profissional na cidade do Rio de Janeiro e está inscrito apenas na OAB/RJ, irá atuar em defesa de um cliente em uma ação penal proposta pelo Ministério Público na Comarca de Salvador/BA. Qual o procedimento a ser seguido pelo advogado? 
-   A. Terá que fazer uma inscrição suplementar na OAB/BA; 
-   B. Terá que fazer a transferência de sua inscrição para a OAB/BA; 
-   C. Poderá patrocinar atuar naquela ação na Bahia, sem inscrição na OAB/BA, mas desde que comunique o patrocínio à OAB/BA e OAB/RJ; 
-   D. Poderá patrocinar atuar naquela causa na Bahia, sem inscrição e sem qualquer comunicação à OAB.
+
+OPTIONS 
+
+A) Terá que fazer uma inscrição suplementar na OAB/BA; 
+
+B) Terá que fazer a transferência de sua inscrição para a OAB/BA; 
+
+C) Poderá patrocinar atuar naquela ação na Bahia, sem inscrição na OAB/BA, mas desde que comunique o patrocínio à OAB/BA e OAB/RJ; 
+
+D) Poderá patrocinar atuar naquela causa na Bahia, sem inscrição e sem qualquer comunicação à OAB.
+
+---
+ENUM Questão 
 26 - Um advogado que está regularmente inscrito na OAB/RJ é escolhido em lista tríplice pelo Governador e empossado no cargo de Desembargador do Tribunal de Justiça do Estado do Rio de Janeiro. Como fica a situação daquele advogado junto à OAB/RJ?
-    A.     O advogado continuará inscrito na OAB/RJ e exercendo livremente a advocacia;
-    B.     O advogado continuará inscrito na OAB/RJ, ficando, entretanto, proibido de advogar apenas contra a Fazenda que o remunera;
-    C.     O advogado terá sua inscrição na OAB/RJ cancelada e, em razão disso, não poderá mais exercer a advocacia enquanto for membro do Poder Judiciário;
-    D.     O advogado será licenciado da advocacia, não podendo advogar apenas durante o tempo em que exercer a atividade de Desembargador.
+
+OPTIONS 
+
+A)     O advogado continuará inscrito na OAB/RJ e exercendo livremente a advocacia;
+
+B)     O advogado continuará inscrito na OAB/RJ, ficando, entretanto, proibido de advogar apenas contra a Fazenda que o remunera;
+
+C)     O advogado terá sua inscrição na OAB/RJ cancelada e, em razão disso, não poderá mais exercer a advocacia enquanto for membro do Poder Judiciário;
+
+D)     O advogado será licenciado da advocacia, não podendo advogar apenas durante o tempo em que exercer a atividade de Desembargador.
+
+---
+ENUM Questão 
 27  -  Carlos Nogueira, advogado do autor, quando fazia a sustentação oral numa Audiência de Instrução e julgamento, na 5ª Vara Cível da Comarca da Capital do Estado do Rio de Janeiro, injuriou e difamou advogado do réu. Sabendo-se que o advogado goza de imunidade profissional (art. 7º, § 2º, da Lei n° 8.906/94), pergunta se: o que pode acontecer com o advogado do autor? 
-   A.     Nada acontecerá ao advogado do autor em razão da imunidade profissional;
-   B.     Ser processado criminalmente pela injúria e difamação proferidas;
-   C.     Ser advertido pelo juiz da 5ª Vara Cível;
-   D.     Ser apenas processado e punido pela OAB/RJ;
+
+OPTIONS 
+
+A)     Nada acontecerá ao advogado do autor em razão da imunidade profissional;
+
+B)     Ser processado criminalmente pela injúria e difamação proferidas;
+
+C)     Ser advertido pelo juiz da 5ª Vara Cível;
+
+D)     Ser apenas processado e punido pela OAB/RJ;
+
+---
+ENUM Questão 
 28  -  Caso um advogado, que já foi punido com a sanção de censura pela OAB/RJ, deixe de pagar a OAB, depois de regularmente notificado pela OAB, e, mesmo assim, não efetuar o pagamento, nem fazer o parcelamento, qual a punição disciplinar poderá ser aplicada àquele advogado? 
-   A.     Censura;
-   B.     Suspensão pelo prazo de trinta dias a doze meses;
-   C.     Exclusão;
-   D.     Suspensão, pelo prazo mínimo de trinta dias, podendo se estender até que pague integralmente a OAB, cumulada com multa de uma a dez anuidades.
+
+OPTIONS 
+
+A)     Censura;
+
+B)     Suspensão pelo prazo de trinta dias a doze meses;
+
+C)     Exclusão;
+
+D)     Suspensão, pelo prazo mínimo de trinta dias, podendo se estender até que pague integralmente a OAB, cumulada com multa de uma a dez anuidades.
+
+---
+ENUM Questão 
 
 29  -  Sobre órgãos da OAB, de acordo com o EAOAB, é incorreto afirmar:
 
-A. De acordo com o atual EAOAB, o Conselho Federal é formado por conselheiros federais integrantes das delegações de cada unidade federativa mais os ex-presidentes que tomaram posse até 1994, pois, de acordo com a nova Lei, não mais integrarão o Conselho Federal aqueles ex-presidentes que passaram a exercer a atividade após o mesmo ano.
-B. Todos os órgãos possuem personalidade jurídica, exceto as subseções.
-C. A Caixa de Assistência dos Advogados tem como base territorial a mesma dos Conselhos Seccionais, ou seja, estados, DF e territórios.
-D. O Conselho Seccional é composto pelos conselheiros seccionais em número proporcional ao número de advogados inscritos, bem como pelos ex-presidentes do Conselho Seccional.
+
+OPTIONS 
+
+A) De acordo com o atual EAOAB, o Conselho Federal é formado por conselheiros federais integrantes das delegações de cada unidade federativa mais os ex-presidentes que tomaram posse até 1994, pois, de acordo com a nova Lei, não mais integrarão o Conselho Federal aqueles ex-presidentes que passaram a exercer a atividade após o mesmo ano.
+
+B) Todos os órgãos possuem personalidade jurídica, exceto as subseções.
+
+C) A Caixa de Assistência dos Advogados tem como base territorial a mesma dos Conselhos Seccionais, ou seja, estados, DF e territórios.
+
+D) O Conselho Seccional é composto pelos conselheiros seccionais em número proporcional ao número de advogados inscritos, bem como pelos ex-presidentes do Conselho Seccional.
+
+---
+ENUM Questão 
 
 
 30  -  Constitui direito do advogado:
 
-A. visitar seu cliente que esteja preso em estabelecimento penitenciário, desde que tenha procuração;
-B. obter vista dos autos de um processo sob segredo de justiça, mesmo sem procuração;
-C. exercer a profissão em todo o território nacional, independentemente do número de causas em cada estado.
-D.  usar a expressão "pela ordem" em qualquer juízo para replicar censura que lhe for feita durante o julgamento.
+
+OPTIONS 
+
+A) visitar seu cliente que esteja preso em estabelecimento penitenciário, desde que tenha procuração;
+
+B) obter vista dos autos de um processo sob segredo de justiça, mesmo sem procuração;
+
+C) exercer a profissão em todo o território nacional, independentemente do número de causas em cada estado.
+
+D)  usar a expressão "pela ordem" em qualquer juízo para replicar censura que lhe for feita durante o julgamento.
+
+---
+ENUM Questão 
 
 
-                           Direito e Processo Penal
-                                       
+Direito e Processo Penal
+
+
 31- Com relação ao concurso de delitos, é correto afirmar que:
 
-A. No concurso de crimes as penas de multa são aplicadas distintamente, mas de forma reduzida.
-B. O concurso material ocorre quando o agente, mediante mais de uma ação ou omissão, pratica dois ou mais crimes com dependência fática e jurídica entre estes.
-C. O concurso formal perfeito, também conhecido como próprio, ocorre quando o agente, por meio de uma só ação ou omissão, pratica dois ou mais crimes idênticos, caso em que as penas serão somadas.
-D. O Código Penal Brasileiro adotou o sistema de aplicação de pena do cúmulo material para os concursos material e formal imperfeito, e da exasperação para o concurso formal perfeito e crime continuado.
+
+OPTIONS 
+
+A) No concurso de crimes as penas de multa são aplicadas distintamente, mas de forma reduzida.
+
+B) O concurso material ocorre quando o agente, mediante mais de uma ação ou omissão, pratica dois ou mais crimes com dependência fática e jurídica entre estes.
+
+C) O concurso formal perfeito, também conhecido como próprio, ocorre quando o agente, por meio de uma só ação ou omissão, pratica dois ou mais crimes idênticos, caso em que as penas serão somadas.
+
+D) O Código Penal Brasileiro adotou o sistema de aplicação de pena do cúmulo material para os concursos material e formal imperfeito, e da exasperação para o concurso formal perfeito e crime continuado.
+
+---
+ENUM Questão 
 
 32- A respeito do regime legal da prescrição no Código Penal, tendo por base ocorrência do fato na data de hoje, assinale a alternativa correta.
 
-A. A prescrição, depois da sentença condenatória com trânsito em julgado para a acusação, regula-se pela pena aplicada, não podendo, em nenhuma hipótese, ter por termo inicial data anterior à da denúncia ou queixa.
-B. A prescrição da pena de multa ocorrerá em 2 (dois) anos, independentemente do prazo estabelecido para a prescrição da pena de liberdade aplicada cumulativamente.
-C. Se o réu citado por edital permanece revel e não constitui advogado, fica suspenso o processo, mantendo-se em curso o prazo prescricional, que passa a ser computado pelo dobro da pena máxima cominada ao crime.
-D. São causas interruptivas do curso da prescrição previstas no Código Penal, dentre outras, o recebimento da denúncia ou da queixa, a pronúncia, a publicação da sentença condenatória ou absolutória recorrível.
+
+OPTIONS 
+
+A) A prescrição, depois da sentença condenatória com trânsito em julgado para a acusação, regula-se pela pena aplicada, não podendo, em nenhuma hipótese, ter por termo inicial data anterior à da denúncia ou queixa.
+
+B) A prescrição da pena de multa ocorrerá em 2 (dois) anos, independentemente do prazo estabelecido para a prescrição da pena de liberdade aplicada cumulativamente.
+
+C) Se o réu citado por edital permanece revel e não constitui advogado, fica suspenso o processo, mantendo-se em curso o prazo prescricional, que passa a ser computado pelo dobro da pena máxima cominada ao crime.
+
+D) São causas interruptivas do curso da prescrição previstas no Código Penal, dentre outras, o recebimento da denúncia ou da queixa, a pronúncia, a publicação da sentença condenatória ou absolutória recorrível.
+
+---
+ENUM Questão 
 
 33- Em 7 de fevereiro de 2010, Ana, utilizando-se do emprego de grave ameaça, constrange seu amigo Lucas, bem-sucedido advogado, a com ela praticar ato libidinoso diverso da conjunção carnal. Em 7 de agosto de 2010, Lucas comparece à delegacia policial para noticiar o crime, tendo sido instaurado inquérito a fim de apurar as circunstâncias do delito. 
+
 A esse respeito, é correto afirmar que o promotor de justiça
 
-   A. Deverá oferecer denúncia contra Ana pela prática do crime de atentado violento ao pudor, haja vista que, por se tratar de crime hediondo, a ação penal é pública incondicionada. 
-   B. Nada poderá fazer, haja vista que os crimes sexuais, que atingem bens jurídicos personalíssimos da vítima, só são persequíveis mediante queixa-crime. 
-   C. Deverá pedir o arquivamento do inquérito por ausência de condição de procedibilidade para a instauração de processo criminal, haja vista que a ação penal é pública condicionada à representação, não tendo a vítima se manifestado dentro do prazo legalmente previsto para tanto. 
-   D. Deverá oferecer denúncia contra Ana pela prática do crime de estupro, haja vista que, com a alteração do Código Penal, passou-se a admitir que pessoa do sexo masculino seja vítima de tal delito, sendo a ação penal pública incondicionada. 
+
+OPTIONS 
+
+A) Deverá oferecer denúncia contra Ana pela prática do crime de atentado violento ao pudor, haja vista que, por se tratar de crime hediondo, a ação penal é pública incondicionada. 
+
+B) Nada poderá fazer, haja vista que os crimes sexuais, que atingem bens jurídicos personalíssimos da vítima, só são persequíveis mediante queixa-crime. 
+
+C) Deverá pedir o arquivamento do inquérito por ausência de condição de procedibilidade para a instauração de processo criminal, haja vista que a ação penal é pública condicionada à representação, não tendo a vítima se manifestado dentro do prazo legalmente previsto para tanto. 
+
+D) Deverá oferecer denúncia contra Ana pela prática do crime de estupro, haja vista que, com a alteração do Código Penal, passou-se a admitir que pessoa do sexo masculino seja vítima de tal delito, sendo a ação penal pública incondicionada. 
+
+---
+ENUM Questão 
 
 34 - Guiando o seu automóvel na contramão de direção, em outubro de 2010, Tício é perseguido por uma viatura da polícia militar. Após ser parado pelos agentes da lei, Tício realiza, espontaneamente, o exame do etilômetro e fornece aos militares sua habilitação e o documento do automóvel. No exame do etilômetro, fica constatado que Tício apresentava concentração de álcool muito superior ao patamar previsto na legislação de trânsito. Além disso, os policiais constatam que o motorista estava com a habilitação vencida desde maio de 2009. 
+
 Com relação ao relatado acima, é correto afirmar que o promotor de justiça deverá denunciar Tício:
 
- A. Pela prática dos crimes de embriaguez ao volante e direção sem habilitação 
- B. Apenas pelo crime de embriaguez ao volante, uma vez que o fato de a habilitação estar vencida constitui mera infração administrativa. 
- C. Apenas pelo crime de direção sem habilitação, uma vez que o perigo gerado por tal conduta faz com que o delito de embriaguez ao volante seja absorvido, em razão da aplicação do Princípio da Consunção. 
- D. Apenas pelo crime de direção sem habilitação, pois o delito de embriaguez ao volante só se configura quando ocorre acidente de trânsito com vítima. 
+
+OPTIONS 
+
+A) Pela prática dos crimes de embriaguez ao volante e direção sem habilitação 
+
+B) Apenas pelo crime de embriaguez ao volante, uma vez que o fato de a habilitação estar vencida constitui mera infração administrativa. 
+
+C) Apenas pelo crime de direção sem habilitação, uma vez que o perigo gerado por tal conduta faz com que o delito de embriaguez ao volante seja absorvido, em razão da aplicação do Princípio da Consunção. 
+
+D) Apenas pelo crime de direção sem habilitação, pois o delito de embriaguez ao volante só se configura quando ocorre acidente de trânsito com vítima. 
+
+---
+ENUM Questão 
 
 35-De acordo com o Código Penal brasileiro é CORRETO afirmar que:
 
-   A. A tentativa perfeita não admite a desistência voluntária
-   B. A desistência voluntária e o arrependimento posterior possuem a mesma conseqüência jurídica, afastar a punição por tentativa e responsabilizar o agente pelos atos já praticados
-   C. A tentativa imperfeita ocorre quando o sujeito, apesar de lançar mão de todos os meios que tinha a seu alcance, não consegue obter o resultado desejado por circunstâncias alheias à sua vontade
-   D. A tentativa branca ou crime falho ocorre quando o sujeito realiza o ato executório, contudo, não atinge o objeto material do delito
+
+OPTIONS 
+
+A) A tentativa perfeita não admite a desistência voluntária
+
+B) A desistência voluntária e o arrependimento posterior possuem a mesma conseqüência jurídica, afastar a punição por tentativa e responsabilizar o agente pelos atos já praticados
+
+C) A tentativa imperfeita ocorre quando o sujeito, apesar de lançar mão de todos os meios que tinha a seu alcance, não consegue obter o resultado desejado por circunstâncias alheias à sua vontade
+
+D) A tentativa branca ou crime falho ocorre quando o sujeito realiza o ato executório, contudo, não atinge o objeto material do delito
+
+---
+ENUM Questão 
 
 36-Segundo a Lei Antidrogas (Lei 11.343/06), julgue os itens abaixo:
 
+
 I) O indiciado ou acusado que colaborar voluntariamente com a investigação policial e o processo criminal na identificação dos demais co-autores ou partícipes do crime e na recuperação total ou parcial do produto do crime, no caso de condenação, terá a pena reduzida de um terço a dois terços
+
 II) O condenado por associação para fins de tráfico deverá cumprir mais de dois quintos da pena para obtenção do livramento condicional.
+
 III) Aquele que instiga, induz ou auxilia alguém ao uso indevido da droga, assim como, oferece a droga, eventualmente e sem objetivo de lucro, a pessoa de seu relacionamento, para junto consumirem, pode se valer da suspensão condicional do processo prevista na Lei 9.099/95.
+
 IV) O juiz na fixação das penas considerará, com preponderância sobre o previsto no art. 59 do Código Penal, a natureza e a quantidade da substância ou produto, a personalidade e a conduta social do agente.
 
-A. Todos os itens estão errados
-B. Todos os itens estão certos
-C. Somente o item III está errado
-D. Somente o item II está errado
+
+OPTIONS 
+
+A) Todos os itens estão errados
+
+B) Todos os itens estão certos
+
+C) Somente o item III está errado
+
+D) Somente o item II está errado
+
+---
+ENUM Questão 
 
 37- O interrogatório do acusado é compreendido doutrinariamente:
 
-A. Meio de obter a confissão do acusado
-B. Meio de estabelecer o contraditório
-C. Meio de defesa
-D. Meio de defesa e de prova
+
+OPTIONS 
+
+A) Meio de obter a confissão do acusado
+
+B) Meio de estabelecer o contraditório
+
+C) Meio de defesa
+
+D) Meio de defesa e de prova
+
+---
+ENUM Questão 
 
 
 38-De que meio legal deverá se utilizar o delegado para ouvir testemunha q reside em outro município:
-   
-         A. Oficio
-         B. Telegrama
-         C. Precatória
-         D. Rogatória
+
+
+OPTIONS 
+
+A) Oficio
+
+B) Telegrama
+
+C) Precatória
+
+D) Rogatória
+
+---
+ENUM Questão 
 
 
 39- A respeito do tema processos em espécie assinale a alternativa q se encontra em conformidade com as recentes alterações introduzidas no CPP:
 
-         A. O procedimento será comum ou especial, o comum será ordinário e sumario e o especial ser sumaríssimo
-         B. Na hipótese de crime cuja sanção máxima cominada for inferior a 4 anos de pena privativa de liberdade aplica-se procedimento ordinário
-         C. Nos procedimentos ordinários e comuns oferecidas a queixa ou a denúncia o juiz ao recebê-la ordenara a citação do acusado para oferecer a defesa por escrito em 10 dias.
-         D. O réu ou seu defensor poderá logo após o interrogatório ou no prazo de 3 dias oferecer alegações escritas e arrolar testemunhas
 
-       
+OPTIONS 
+
+A) O procedimento será comum ou especial, o comum será ordinário e sumario e o especial ser sumaríssimo
+
+B) Na hipótese de crime cuja sanção máxima cominada for inferior a 4 anos de pena privativa de liberdade aplica-se procedimento ordinário
+
+C) Nos procedimentos ordinários e comuns oferecidas a queixa ou a denúncia o juiz ao recebê-la ordenara a citação do acusado para oferecer a defesa por escrito em 10 dias.
+
+D) O réu ou seu defensor poderá logo após o interrogatório ou no prazo de 3 dias oferecer alegações escritas e arrolar testemunhas
+
+---
+ENUM Questão 
+
+
 40- As partes possuem o direito de na relação processual insurgirem-se contra decisões judiciais requerendo a sua revisão total ou parcial em instância superior. Para tanto, o CPP enumera diversos recursos objetivando o livre e pleno exercício do direito de ação e de defesa. Nesse contexto assinale a alternativa correta: 
 
-         A. MP poderá desistir de recurso que haja interposto
-         B. Caberá RSE da decisão, despacho ou sentença que pronunciar ou impronunciar o réu
-         C. Os embargos de declaração poderão ser opostos no prazo de 48 h contados da publicação do acórdão
-         D. Contra sentença de impronúncia ou absolvição sumária caberá apelação
+
+OPTIONS 
+
+A) MP poderá desistir de recurso que haja interposto
+
+B) Caberá RSE da decisão, despacho ou sentença que pronunciar ou impronunciar o réu
+
+C) Os embargos de declaração poderão ser opostos no prazo de 48 h contados da publicação do acórdão
+
+D) Contra sentença de impronúncia ou absolvição sumária caberá apelação
+
+---
+ENUM Questão 
 
 
-                                  Empresarial
-                                       
+Empresarial
+
+
 41 - Com base na disciplina jurídica das sociedades anônimas, julgue os seguintes itens.
 
+
 I - As sociedades por ações podem ser classificadas em abertas ou fechadas, considerando-se a participação do Estado em seu capital social.
+
 II - A Comissão de Valores Mobiliários, entidade autárquica em regime especial vinculada ao Ministério da Fazenda, é responsável pela emissão de ações em mercado primário.
+
 III - Ações preferenciais são aquelas que conferem ao seu titular uma vantagem na distribuição dos lucros sociais entre os acionistas e podem, exatamente por isso, ter limitado ou suprimido o direito de voto.
+
 IV - As ações, as debêntures, os bônus de subscrição e as partes beneficiárias, entre outras, são espécies de valores mobiliários emitidos pelas companhias para a captação de recursos.
+
 V - O valor nominal da ação é alcançado com a sua venda no ambiente de bolsa de valores.
+
 Estão certos apenas os itens:
 
-A. III e IV.
-B. I e V.
-C. II e III.
-D. I, II, IV e V.
+
+OPTIONS 
+
+A) III e IV.
+
+B) I e V.
+
+C) II e III.
+
+D) I, II, IV e V.
+
+---
+ENUM Questão 
 
 42 - A sociedade simples difere, essencialmente, da sociedade empresária por que:
 
-A. Naquela, a responsabilidade dos sócios é sempre subsidiária, enquanto nesta, é sempre limitada.
-B. Aquela não exerce atividade própria de empresário sujeito a registro, ao contrário do que ocorre nesta.
-C. Aquela deve constituir-se apenas sob as normas que lhe são próprias, enquanto esta pode constituir-se utilizando-se de diversos tipos.
-D. Aquela não exerce atividade econômica nem visa ao lucro, ao contrário desta.
+
+OPTIONS 
+
+A) Naquela, a responsabilidade dos sócios é sempre subsidiária, enquanto nesta, é sempre limitada.
+
+B) Aquela não exerce atividade própria de empresário sujeito a registro, ao contrário do que ocorre nesta.
+
+C) Aquela deve constituir-se apenas sob as normas que lhe são próprias, enquanto esta pode constituir-se utilizando-se de diversos tipos.
+
+D) Aquela não exerce atividade econômica nem visa ao lucro, ao contrário desta.
+
+---
+ENUM Questão 
 QUESTÃO 27
+
 43 - Com relação às regras que disciplinam a situação do sócio-quotista da sociedade limitada, assinale a opção correta.
 
-A. As quotas são bens de livre disposição do sócio, que poderá vendê-las a outro sócio ou a terceiro, independentemente da anuência dos demais sócios.
-B. As quotas representam a necessária divisão do capital social em partes iguais, sendo as deliberações consideradas de acordo com o número de quotas de cada sócio.
-C. A responsabilidade dos sócios é restrita ao valor de suas quotas, mas todos respondem pela integralização do capital social.
-D. As quotas podem ser integralizadas pelos sócios por valores representados em dinheiro, bens ou prestação de serviços, respondendo solidariamente todos os sócios pela exata estimação dessas contribuições.
+
+OPTIONS 
+
+A) As quotas são bens de livre disposição do sócio, que poderá vendê-las a outro sócio ou a terceiro, independentemente da anuência dos demais sócios.
+
+B) As quotas representam a necessária divisão do capital social em partes iguais, sendo as deliberações consideradas de acordo com o número de quotas de cada sócio.
+
+C) A responsabilidade dos sócios é restrita ao valor de suas quotas, mas todos respondem pela integralização do capital social.
+
+D) As quotas podem ser integralizadas pelos sócios por valores representados em dinheiro, bens ou prestação de serviços, respondendo solidariamente todos os sócios pela exata estimação dessas contribuições.
+
+---
+ENUM Questão 
 
 44 - Assinale a opção correta:
 
-A. A qualificação de uma sociedade como empresarial só ocorre quando ela exerce atividade própria de empresário sujeito a registro.
-B. A sociedade que precipuamente exercer atividade de empresário rural só poderá adotar tipo reservado às sociedades empresárias.
-C. A constituição de sociedade para a realização de apenas um negócio determinado é incompatível com a atividade empresarial, pois impede a habitualidade de seu exercício.
-D. O conceito de sociedade implica o exercício de atividade econômica, embora nem toda sociedade que realize atividade econômica seja necessariamente considerada empresarial.
+
+OPTIONS 
+
+A) A qualificação de uma sociedade como empresarial só ocorre quando ela exerce atividade própria de empresário sujeito a registro.
+
+B) A sociedade que precipuamente exercer atividade de empresário rural só poderá adotar tipo reservado às sociedades empresárias.
+
+C) A constituição de sociedade para a realização de apenas um negócio determinado é incompatível com a atividade empresarial, pois impede a habitualidade de seu exercício.
+
+D) O conceito de sociedade implica o exercício de atividade econômica, embora nem toda sociedade que realize atividade econômica seja necessariamente considerada empresarial.
+
+---
+ENUM Questão 
 
 45 - Com base na Lei n.º 6.406/1976, que dispõe sobre as sociedades por ações, assinale a opção correta acerca das características jurídicas desse tipo de sociedade empresarial.
 
-A. Nessas sociedades, apenas acionistas poderão ser simultaneamente titulares de ações e debêntures.
-B. As partes beneficiárias compõem o capital social desse tipo de sociedade, sendo permitida a participação nos lucros anuais.
-C. As ações, quanto à forma, podem ser classificadas em ordinárias e preferenciais.
-D. Os bônus de subscrição conferem direito de crédito contra a companhia, podendo conter garantia real ou flutuante.
+
+OPTIONS 
+
+A) Nessas sociedades, apenas acionistas poderão ser simultaneamente titulares de ações e debêntures.
+
+B) As partes beneficiárias compõem o capital social desse tipo de sociedade, sendo permitida a participação nos lucros anuais.
+
+C) As ações, quanto à forma, podem ser classificadas em ordinárias e preferenciais.
+
+D) Os bônus de subscrição conferem direito de crédito contra a companhia, podendo conter garantia real ou flutuante.
+
+---
+ENUM Questão 
 
 
 
-                           Direito e Processo Civil
-                                       
+Direito e Processo Civil
+
+
 46 - A audiência de instrução e julgamento (AIJ) é ato passível de ser realizado nos procedimentos ordinário, sumário e no previsto pela Lei n.º 9.099/2005, dos juizados especiais cíveis. Entretanto, a finalidade da AIJ nos juizados não é exatamente a mesma daquela realizada nos procedimentos ordinário e sumário, pois, certos atos que, nos juizados, devem ser realizados nessa audiência, já ocorreram anteriormente nos procedimentos ditos comuns. Nesse sentido,
 
-A. A prova pericial com o auxílio de assistentes técnicos e diligências, que nos juizados só é admitida na AIJ, nos procedimentos ordinário e sumário realiza-se antes dessa audiência.
-B. a conciliação, cuja tentativa pelo juízo ainda é admitida na AIJ do juizado, não mais ocorre na AIJ dos procedimentos ordinário e sumário.
-C. a prova testemunhal, que só é admitida na AIJ do juizado, na AIJ dos procedimentos ordinário e sumário só é admitida, respectivamente, na audiência preliminar prevista no art. 331 do Código de Processo Civil (CPC) e na audiência prevista no art. 277 do CPC.
-D. A contestação, que nos juizados deve ser apresentada na AIJ, no procedimento ordinário já foi anteriormente apresentada.
+
+OPTIONS 
+
+A) A prova pericial com o auxílio de assistentes técnicos e diligências, que nos juizados só é admitida na AIJ, nos procedimentos ordinário e sumário realiza-se antes dessa audiência.
+
+B) a conciliação, cuja tentativa pelo juízo ainda é admitida na AIJ do juizado, não mais ocorre na AIJ dos procedimentos ordinário e sumário.
+
+C) a prova testemunhal, que só é admitida na AIJ do juizado, na AIJ dos procedimentos ordinário e sumário só é admitida, respectivamente, na audiência preliminar prevista no art. 331 do Código de Processo Civil (CPC) e na audiência prevista no art. 277 do CPC.
+
+D) A contestação, que nos juizados deve ser apresentada na AIJ, no procedimento ordinário já foi anteriormente apresentada.
+
+---
+ENUM Questão 
 
 47- A respeito da petição inicial e da resposta do réu, assinale a opção correta.
 
-A. Contra a decisão que indefere total ou parcialmente a petição inicial, o recurso cabível é a apelação. Quando for interposto esse recurso, cabe juízo de retratação da sentença, podendo o juiz modificar sua decisão e determinar a citação do réu.
-B. O não-comparecimento do réu ao processo, para praticar uma das modalidades de resposta, gera, de regra, presunção de veracidade dos fatos afirmados pelo autor e exonera o juiz de intimar o réu dos atos processuais praticados. No entanto, esse revel poderá intervir no processo em qualquer fase, recebendo-o no estado em que se encontrar.
-C. A reconvenção é cabível em qualquer procedimento, inclusive nas ações dúplices, desde que satisfeitos os pressupostos processuais e as condições da ação. Não obstante a autonomia da reconvenção, o manejo dela exige a sua apresentação em petição escrita, simultaneamente com a contestação.
-D. Quando for proposta uma ação em que a pretensão do autor seja daquelas em que a matéria controvertida seja de direito ou, sendo de fato, já existam outras causas idênticas, poderá o juiz julgar liminarmente a lide, rejeitando ou acolhendo o pedido do autor.
+
+OPTIONS 
+
+A) Contra a decisão que indefere total ou parcialmente a petição inicial, o recurso cabível é a apelação. Quando for interposto esse recurso, cabe juízo de retratação da sentença, podendo o juiz modificar sua decisão e determinar a citação do réu.
+
+B) O não-comparecimento do réu ao processo, para praticar uma das modalidades de resposta, gera, de regra, presunção de veracidade dos fatos afirmados pelo autor e exonera o juiz de intimar o réu dos atos processuais praticados. No entanto, esse revel poderá intervir no processo em qualquer fase, recebendo-o no estado em que se encontrar.
+
+C) A reconvenção é cabível em qualquer procedimento, inclusive nas ações dúplices, desde que satisfeitos os pressupostos processuais e as condições da ação. Não obstante a autonomia da reconvenção, o manejo dela exige a sua apresentação em petição escrita, simultaneamente com a contestação.
+
+D) Quando for proposta uma ação em que a pretensão do autor seja daquelas em que a matéria controvertida seja de direito ou, sendo de fato, já existam outras causas idênticas, poderá o juiz julgar liminarmente a lide, rejeitando ou acolhendo o pedido do autor.
+
+---
+ENUM Questão 
 
 48- A respeito das partes e dos procuradores, assinale a opção correta.
 
-A. Ao réu preso, ainda que tenha sido citado pessoalmente, deve ser nomeado curador especial, que tem a
+
+OPTIONS 
+
+A) Ao réu preso, ainda que tenha sido citado pessoalmente, deve ser nomeado curador especial, que tem a
+
 incumbência de contestar o feito, sendo-lhe vedado manifestar-se contrariamente àquele que representa.
-B. No caso de falecimento do procurador do réu, ainda que iniciada a audiência de instrução e julgamento, o juiz deve determinar a suspensão do processo e marcar prazo para que o réu constitua novo mandatário. Findo o prazo, se o réu não cumprir a determinação, o juiz deve determinar o prosseguimento do processo e garantir ao réu curador especial.
-C. A alienação da coisa litigiosa, no curso do processo, altera a legitimidade das partes, devendo prosseguir a demanda entre adquirente em substituição ao alienante e a parte contrária originária. A decisão proferida na causa em que atua o substituto processual faz coisa julgada para o substituído.
-D. A outorga de procuração para o foro, em geral, habilita o advogado a praticar todos os atos do processo em nome da parte, podendo ele receber e dar quitação, reconhecer a procedência do pedido e firmar qualquer compromisso.
+
+B) No caso de falecimento do procurador do réu, ainda que iniciada a audiência de instrução e julgamento, o juiz deve determinar a suspensão do processo e marcar prazo para que o réu constitua novo mandatário. Findo o prazo, se o réu não cumprir a determinação, o juiz deve determinar o prosseguimento do processo e garantir ao réu curador especial.
+
+C) A alienação da coisa litigiosa, no curso do processo, altera a legitimidade das partes, devendo prosseguir a demanda entre adquirente em substituição ao alienante e a parte contrária originária. A decisão proferida na causa em que atua o substituto processual faz coisa julgada para o substituído.
+
+D) A outorga de procuração para o foro, em geral, habilita o advogado a praticar todos os atos do processo em nome da parte, podendo ele receber e dar quitação, reconhecer a procedência do pedido e firmar qualquer compromisso.
+
+---
+ENUM Questão 
 
 49- Quanto às nulidades processuais, assinale a opção correta.
 
-A. O ato processual praticado em desconformidade com a norma que disciplina sua produção é inválido, devendo o juiz, de ofício, decretar sua nulidade e determinar sua repetição, ainda que não cause prejuízo à regularidade processual ou às partes.
-B. Deve ser decretada a nulidade do processo em que se tenha constatado, afinal, a falta de outorga uxória, ainda que se possa decidir o mérito a favor do cônjuge ausente, visto que todas as nulidades processuais são insanáveis.
-C. A nulidade relativa deve ser argüida pela parte interessada em sua decretação, na primeira oportunidade em que lhe couber falar nos autos, depois do ato defeituoso, sob pena de preclusão, isto é, de perda da faculdade processual de promover a anulação.
-D. Anulado um ato processual, mesmo que se trate de um ato complexo, todos os atos subseqüentes a ele serão também anulados, ainda que sejam independentes entre si e que a nulidade se refira a apenas uma parte do ato. 
+
+OPTIONS 
+
+A) O ato processual praticado em desconformidade com a norma que disciplina sua produção é inválido, devendo o juiz, de ofício, decretar sua nulidade e determinar sua repetição, ainda que não cause prejuízo à regularidade processual ou às partes.
+
+B) Deve ser decretada a nulidade do processo em que se tenha constatado, afinal, a falta de outorga uxória, ainda que se possa decidir o mérito a favor do cônjuge ausente, visto que todas as nulidades processuais são insanáveis.
+
+C) A nulidade relativa deve ser argüida pela parte interessada em sua decretação, na primeira oportunidade em que lhe couber falar nos autos, depois do ato defeituoso, sob pena de preclusão, isto é, de perda da faculdade processual de promover a anulação.
+
+D) Anulado um ato processual, mesmo que se trate de um ato complexo, todos os atos subseqüentes a ele serão também anulados, ainda que sejam independentes entre si e que a nulidade se refira a apenas uma parte do ato. 
+
+---
+ENUM Questão 
 
 50- Acerca da resposta do réu, assinale a opção correta.
 
-A. No caso de a incompetência do juízo, absoluta ou relativa, não ser alegada como preliminar na contestação, ocorrerá a chamada prorrogação de competência.
-B. Ocorrendo a conexão de ações propostas em separado, o juiz pode, a pedido do réu como preliminar da contestação e, não, de ofício, determinar a reunião das ações para que sejam decididas na mesma sentença.
-C. Caso o réu compareça em juízo para apontar a inexistência ou a invalidade da citação e esta não seja acolhida, o juiz deve, no mesmo despacho, determinar nova citação do réu e a reabertura do prazo para resposta, de modo que este deduza o restante da defesa.
-D. Em obediência ao princípio da concentração das defesas, o réu deve alegar, na contestação, toda a matéria de defesa, exceto aquelas que devem ser veiculadas através de exceção, ainda que uma somente possa ser acolhida caso outra seja rejeitada 
+
+OPTIONS 
+
+A) No caso de a incompetência do juízo, absoluta ou relativa, não ser alegada como preliminar na contestação, ocorrerá a chamada prorrogação de competência.
+
+B) Ocorrendo a conexão de ações propostas em separado, o juiz pode, a pedido do réu como preliminar da contestação e, não, de ofício, determinar a reunião das ações para que sejam decididas na mesma sentença.
+
+C) Caso o réu compareça em juízo para apontar a inexistência ou a invalidade da citação e esta não seja acolhida, o juiz deve, no mesmo despacho, determinar nova citação do réu e a reabertura do prazo para resposta, de modo que este deduza o restante da defesa.
+
+D) Em obediência ao princípio da concentração das defesas, o réu deve alegar, na contestação, toda a matéria de defesa, exceto aquelas que devem ser veiculadas através de exceção, ainda que uma somente possa ser acolhida caso outra seja rejeitada 
+
+---
+ENUM Questão 
 
 51 - Em 2004, Thiago, que não tinha herdeiros necessários, lavrou um testamento contemplando como sua herdeira universal Bruna. Em 2006, arrependido, Thiago revogou o testamento de 2004, nomeando como seu herdeiro universal Mauro. Em 2008, Mauro faleceu, deixando uma filha Rita. No mês de julho de 2010, faleceu Thiago. O único parente vivo de Thiago era seu irmão, Saulo. Assinale a alternativa que indique a quem caberá a herança de Thiago.
 
-A. Saulo.
-B. Rita.
-C. Bruna.
-D. A herança será vacante.
+
+OPTIONS 
+
+A) Saulo.
+
+B) Rita.
+
+C) Bruna.
+
+D) A herança será vacante.
+
+---
+ENUM Questão 
 
 52 - Platão prometeu transferir a propriedade de uma coisa certa, mas antes disso, sem culpa sua, o bem foi deteriorado. Segundo o Código Civil, ao caso de Platão aplica-se o seguinte regime jurídico:
 
-A. a obrigação fica resolvida, com a devolução de valores eventualmente pagos.
-B. a obrigação subsiste, com a entrega da coisa no estado em que se encontra.
-C. a obrigação subsiste, com a entrega da coisa no estado em que se encontra e abati mento no preço proporcional à deterioração.
-D. a obrigação poderá ser resolvida, com a devolução de valores eventualmente pagos, ou subsisti r, com a entrega da coisa no estado em que se encontra e abati mento no preço proporcional à deterioração, cabendo ao credor a escolha de uma dentre as duas soluções.TÃO 43
+
+OPTIONS 
+
+A) a obrigação fica resolvida, com a devolução de valores eventualmente pagos.
+
+B) a obrigação subsiste, com a entrega da coisa no estado em que se encontra.
+
+C) a obrigação subsiste, com a entrega da coisa no estado em que se encontra e abati mento no preço proporcional à deterioração.
+
+D) a obrigação poderá ser resolvida, com a devolução de valores eventualmente pagos, ou subsisti r, com a entrega da coisa no estado em que se encontra e abati mento no preço proporcional à deterioração, cabendo ao credor a escolha de uma dentre as duas soluções.TÃO 43
+
+---
+ENUM Questão 
 
 53 - Por meio de uma promessa de compra e venda, celebrada por instrumento particular registrada no cartório de Registro de Imóveis e na qual não se pactuou arrependimento, Raul foi residir no imóvel objeto do contrato e, quando quitou o pagamento, deparou-se com a recusa do promitente-vendedor em outorgar-lhe a escritura definitiva do imóvel. Diante do impasse, Raul poderá:
 
-A. requerer ao juiz a adjudicação do imóvel, a despeito de a promessa de compra e venda ter sido celebrada por instrumento particular.
-B. usucapir o imóvel, já que não faria jus à adjudicação compulsória na hipótese.
-C. desistir do negócio e pedir o dinheiro de volta.
-D. exigir a substituição do imóvel prometi do à venda por outro, muito embora inexistisse previsão expressa a esse respeito no contrato preliminar.
+
+OPTIONS 
+
+A) requerer ao juiz a adjudicação do imóvel, a despeito de a promessa de compra e venda ter sido celebrada por instrumento particular.
+
+B) usucapir o imóvel, já que não faria jus à adjudicação compulsória na hipótese.
+
+C) desistir do negócio e pedir o dinheiro de volta.
+
+D) exigir a substituição do imóvel prometi do à venda por outro, muito embora inexistisse previsão expressa a esse respeito no contrato preliminar.
+
+---
+ENUM Questão 
 
 54 - Assinale a opção correta no que se refere aos contratos tipificados no Código Civil brasileiro.
 
-A. No contrato de doação, são revogáveis por ingratidão as doações puramente remuneratórias e as oneradas com encargo já cumprido.
-B. Tanto o contrato de empreitada quanto o de prestação de serviço geram obrigação de resultado.
-C. O contrato de compra e venda subordinado à condição de dissolução caso o objeto do contrato não seja do agrado do comprador denomina-se venda a contento, cláusula sempre presumida nos contratos de compra e venda.
-D. O contrato estimatório é aleatório e deve ter por objeto coisa móvel.
+
+OPTIONS 
+
+A) No contrato de doação, são revogáveis por ingratidão as doações puramente remuneratórias e as oneradas com encargo já cumprido.
+
+B) Tanto o contrato de empreitada quanto o de prestação de serviço geram obrigação de resultado.
+
+C) O contrato de compra e venda subordinado à condição de dissolução caso o objeto do contrato não seja do agrado do comprador denomina-se venda a contento, cláusula sempre presumida nos contratos de compra e venda.
+
+D) O contrato estimatório é aleatório e deve ter por objeto coisa móvel.
+
+---
+ENUM Questão 
 
 55 - No que se refere aos institutos da posse e da propriedade, assinale a opção correta.
 
-A. Ao possuidor de má-fé serão ressarcidas somente as benfeitorias necessárias e úteis, não lhe assistindo o direito de retenção pela importância das benfeitorias necessárias.
-B. Caracteriza usucapião a posse, por cinco anos, de coisa móvel, desde que comprovada a boa-fé do possuidor.
-C. Aquele que semeia, planta ou edifica em terreno alheio perde, em proveito do proprietário, as sementes, plantas e construções, com direito a indenização se procede de boa-fé.
-D. A posse direta, de pessoa que tem a coisa em seu poder, temporariamente, em virtude de direito pessoal, ou real, anula a indireta, de quem aquela foi havida.
 
-                        Direito e Processo do Trabalho
+OPTIONS 
+
+A) Ao possuidor de má-fé serão ressarcidas somente as benfeitorias necessárias e úteis, não lhe assistindo o direito de retenção pela importância das benfeitorias necessárias.
+
+B) Caracteriza usucapião a posse, por cinco anos, de coisa móvel, desde que comprovada a boa-fé do possuidor.
+
+C) Aquele que semeia, planta ou edifica em terreno alheio perde, em proveito do proprietário, as sementes, plantas e construções, com direito a indenização se procede de boa-fé.
+
+D) A posse direta, de pessoa que tem a coisa em seu poder, temporariamente, em virtude de direito pessoal, ou real, anula a indireta, de quem aquela foi havida.
+
+---
+ENUM Questão 
+
+Direito e Processo do Trabalho
+
 
 
 56- Camila ajuizou reclamação trabalhista com pedido de pagamento de adicional de periculosidade referente aos 10 últimos meses do contrato de trabalho. Em defesa, a reclamada diz que pagava anteriormente por mera liberalidade. Nesta hipótese:
 
-A. Indispensável a produção de prova pericial.
-B. Dispensável a produção de prova pericial.
-C. Será indispensável se Camila requerer o adicional no grau máximo.
-D. Será dispensável se Camila requerer o adicional no grau mínimo.
+
+OPTIONS 
+
+A) Indispensável a produção de prova pericial.
+
+B) Dispensável a produção de prova pericial.
+
+C) Será indispensável se Camila requerer o adicional no grau máximo.
+
+D) Será dispensável se Camila requerer o adicional no grau mínimo.
+
+---
+ENUM Questão 
 
 57- Julia, jornalista, foi contratada para exercer as funções típicas de jornalista em uma rede de supermercados. Neste caso, sua jornada de trabalho:
 
-A. Não deverá exceder de 5 horas.
-B. Não deverá exceder de 8 horas.
-C. Não deverá exceder de 8 horas, salvo se tiver outro emprego.
-D. Não deverá exceder de 5 horas, salvo de tiver outro emprego.
+
+OPTIONS 
+
+A) Não deverá exceder de 5 horas.
+
+B) Não deverá exceder de 8 horas.
+
+C) Não deverá exceder de 8 horas, salvo se tiver outro emprego.
+
+D) Não deverá exceder de 5 horas, salvo de tiver outro emprego.
+
+---
+ENUM Questão 
 
 58- Por determinação de seu empregador, Marília entrou de férias no dia 5/9/2011 (segunda-feira), e, recebeu o pagamento das férias com o terço constitucional no dia 9/5/2011 (sexta-feira). Marília,
 
-A. Tem direito ao pagamento em dobro dos 4 primeiros dias de férias.
-B. Tem direito ao pagamento em dobro dos 4 primeiros dias de férias, incluído o terço constitucional.
-C. Tem direito ao pagamento em dobro da remuneração de férias, incluído o terço constitucional.
-D. Não direito a qualquer outro pagamento das férias.
+
+OPTIONS 
+
+A) Tem direito ao pagamento em dobro dos 4 primeiros dias de férias.
+
+B) Tem direito ao pagamento em dobro dos 4 primeiros dias de férias, incluído o terço constitucional.
+
+C) Tem direito ao pagamento em dobro da remuneração de férias, incluído o terço constitucional.
+
+D) Não direito a qualquer outro pagamento das férias.
+
+---
+ENUM Questão 
 
 59- Devido ao mercado favorável, Thiago, contratado para cumprir jornada de seis horas de trabalho, está trabalhando habitualmente duas horas extraordinárias diárias. Nesta hipótese:
 
-A. Será obrigatório um intervalo intrajornada de 15 (quinze) minutos após a 4ª hora, e outro, de 15 minutos, antes do início da jornada extraordinária.
-B. Será obrigatório apenas um intervalo intrajornada de 15 (quinze) minutos.
-C. No mínimo de uma hora, obrigando o empregador a remunerar o período para descanso e alimentação não usufruído como parcela indenizatória. 
-D. No mínimo de uma hora, obrigando o empregador a remunerar o período para descanso e alimentação não usufruído como extra, acrescido do respectivo adicional.
+
+OPTIONS 
+
+A) Será obrigatório um intervalo intrajornada de 15 (quinze) minutos após a 4ª hora, e outro, de 15 minutos, antes do início da jornada extraordinária.
+
+B) Será obrigatório apenas um intervalo intrajornada de 15 (quinze) minutos.
+
+C) No mínimo de uma hora, obrigando o empregador a remunerar o período para descanso e alimentação não usufruído como parcela indenizatória. 
+
+D) No mínimo de uma hora, obrigando o empregador a remunerar o período para descanso e alimentação não usufruído como extra, acrescido do respectivo adicional.
+
+---
+ENUM Questão 
 
 60- Pedro, gerente de divisão, recebeu do seu empregador um aparelho de telefone "nextel", onde recebia mensagens e chamadas via rádio, mesmo após o término da jornada contratual. Um mês após, solicitou o pagamento de sobreaviso. Diante do requerimento apresentado, o empregador:
 
-A. Pagará apenas os minutos efetivamente ocupados com a leitura de mensagens e conversas telefônicas, com o adicional de horas extras.
-B. Pagará apenas os minutos efetivamente ocupados com a leitura de mensagens e conversas telefônicas, sem o adicional de horas extras.
-C. Pagará apenas os minutos efetivamente ocupados com a leitura de mensagens e conversas telefônicas, como sobreaviso.
-D. Não pagará qualquer valor, pois o uso do aparelho, por si só, não caracteriza o regime de sobreaviso.
+
+OPTIONS 
+
+A) Pagará apenas os minutos efetivamente ocupados com a leitura de mensagens e conversas telefônicas, com o adicional de horas extras.
+
+B) Pagará apenas os minutos efetivamente ocupados com a leitura de mensagens e conversas telefônicas, sem o adicional de horas extras.
+
+C) Pagará apenas os minutos efetivamente ocupados com a leitura de mensagens e conversas telefônicas, como sobreaviso.
+
+D) Não pagará qualquer valor, pois o uso do aparelho, por si só, não caracteriza o regime de sobreaviso.
+
+---
+ENUM Questão 
 
 61- Lucas, representante suplente dos empregados, membro de Comissão de Conciliação Prévia, foi suspenso por cinco dias em razão da prática de falta grave passível de demissão por justa causa. Neste caso, seu empregador:
 
-A. Deverá ajuizar reclamação escrita ou verbal a fim de instaurar inquérito para apuração de falta grave perante uma das Varas do Trabalho, dentro de quinze dias, contados da data da suspensão de Lucas.
-B. Deverá ajuizar reclamação escrita a fim de instaurar inquérito para apuração de falta grave perante uma das Varas do Trabalho, dentro de trinta dias, contados da data da suspensão de Lucas.
-C. Poderá dispensar Lucas após o término da pena de suspensão aplicada, tendo em vista que o membro suplente de Comissão de Conciliação Prévia não possui estabilidade.
-D. Poderá dispensar Lucas imediatamente, tendo em vista que o membro suplente de Comissão de Conciliação Prévia não possui estabilidade.
+
+OPTIONS 
+
+A) Deverá ajuizar reclamação escrita ou verbal a fim de instaurar inquérito para apuração de falta grave perante uma das Varas do Trabalho, dentro de quinze dias, contados da data da suspensão de Lucas.
+
+B) Deverá ajuizar reclamação escrita a fim de instaurar inquérito para apuração de falta grave perante uma das Varas do Trabalho, dentro de trinta dias, contados da data da suspensão de Lucas.
+
+C) Poderá dispensar Lucas após o término da pena de suspensão aplicada, tendo em vista que o membro suplente de Comissão de Conciliação Prévia não possui estabilidade.
+
+D) Poderá dispensar Lucas imediatamente, tendo em vista que o membro suplente de Comissão de Conciliação Prévia não possui estabilidade.
+
+---
+ENUM Questão 
 
 62- Das decisões finais prolatadas em ações rescisórias:
 
-A. Não caberá recurso.
-B. Caberá mandado de segurança ao Tribunal Superior do Trabalho.
-C. Caberá recurso ordinário ao Tribunal Superior do Trabalho.
-D. Caberá recurso ordinário ao Tribunal Regional do Trabalho competente.
+
+OPTIONS 
+
+A) Não caberá recurso.
+
+B) Caberá mandado de segurança ao Tribunal Superior do Trabalho.
+
+C) Caberá recurso ordinário ao Tribunal Superior do Trabalho.
+
+D) Caberá recurso ordinário ao Tribunal Regional do Trabalho competente.
+
+---
+ENUM Questão 
 
 63- Daniel, advogada de Caroline, pretende ajuizar reclamação trabalhista cujo valor da causa é de R$ 12.000,00. Neste caso, em regra,
 
-A. Daniel deverá arrolar previamente até duas testemunhas na petição inicial, sob pena de preclusão.
-B. Na data da audiência, Caroline deverá trazer até três testemunhas, independentemente de intimação.
-C. O pedido deverá ser certo e determinado, indicando o valor de R$ 12.000,00.
-D. Daniel poderá requerer a citação por edital se a empresa ré, comprovadamente, possuir endereço incerto.
+
+OPTIONS 
+
+A) Daniel deverá arrolar previamente até duas testemunhas na petição inicial, sob pena de preclusão.
+
+B) Na data da audiência, Caroline deverá trazer até três testemunhas, independentemente de intimação.
+
+C) O pedido deverá ser certo e determinado, indicando o valor de R$ 12.000,00.
+
+D) Daniel poderá requerer a citação por edital se a empresa ré, comprovadamente, possuir endereço incerto.
+
+---
+ENUM Questão 
 
 64- Assinale a alternativa correta:
 
-A. É válido o instrumento de mandato com prazo determinado que contém cláusula estabelecendo a prevalência dos poderes para atuar até o final da demanda.
-B. É admissível em instância recursal, o oferecimento tardio de procuração, ainda que mediante protesto por posterior juntada, já que a interposição de recurso não pode ser reputada ato urgente.
-C. Nas Reclamatórias Plúrimas os empregados não poderão fazer-se representar pelo Sindicato de sua categoria, tendo em vista que não se trata de dissídio coletivo, mas sim de dissídio individual com diversos reclamantes.
-D. Não configura irregularidade de representação o fato de o substabelecimento ser anterior à outorga passada ao substabelecente, tratando-se de mera irregularidade formal.
+
+OPTIONS 
+
+A) É válido o instrumento de mandato com prazo determinado que contém cláusula estabelecendo a prevalência dos poderes para atuar até o final da demanda.
+
+B) É admissível em instância recursal, o oferecimento tardio de procuração, ainda que mediante protesto por posterior juntada, já que a interposição de recurso não pode ser reputada ato urgente.
+
+C) Nas Reclamatórias Plúrimas os empregados não poderão fazer-se representar pelo Sindicato de sua categoria, tendo em vista que não se trata de dissídio coletivo, mas sim de dissídio individual com diversos reclamantes.
+
+D) Não configura irregularidade de representação o fato de o substabelecimento ser anterior à outorga passada ao substabelecente, tratando-se de mera irregularidade formal.
+
+---
+ENUM Questão 
 
 65- O jus postulandi das partes, estabelecido na Consolidação das Leis do Trabalho,
 
-A. Limita-se às Varas do Trabalho, alcançando ação rescisória de sua competência.
-B. Limita-se às Varas do Trabalho, alcançando os mandados de segurança de sua competência. 
-C. É ilimitado, não havendo na lei, em Súmulas ou Orientações Jurisprudenciais qualquer limitação, pois trata-se de direito assegurado pela Constituição Federal.
-D. Limita-se às Varas do Trabalho e aos Tribunais Regionais do Trabalho, não alcançando os recursos de competência do Tribunal Superior do Trabalho.
 
-                              Direito Tributário
-                                       
+OPTIONS 
+
+A) Limita-se às Varas do Trabalho, alcançando ação rescisória de sua competência.
+
+B) Limita-se às Varas do Trabalho, alcançando os mandados de segurança de sua competência. 
+
+C) É ilimitado, não havendo na lei, em Súmulas ou Orientações Jurisprudenciais qualquer limitação, pois trata-se de direito assegurado pela Constituição Federal.
+
+D) Limita-se às Varas do Trabalho e aos Tribunais Regionais do Trabalho, não alcançando os recursos de competência do Tribunal Superior do Trabalho.
+
+---
+ENUM Questão 
+
+Direito Tributário
+
+
 66- Quanto ao instituto da imputação, assinale a alternativa correta de acordo com o entendimento atual do STJ:
 
-A. Em dívida tributária composta por capital e juros, o pagamento imputar-se-á primeiro no capital e, depois, nos juros vencidos, salvo se a lei dispuser o contrário.
-B. Em dívida composta por capital e juros, o pagamento imputar-se-á primeiro nos juros vencidos e, depois, no capital, não importando a vontade das partes.
-C. Às compensações tributárias aplica-se subsidiariamente a regra de imputação estipulada no Código Civil, tendo em vista a ausência de lei tributária específica sobre a matéria.
-D. Às compensações tributárias não se aplica a regra de imputação de pagamentos estipulada no Código Civil, ainda que não haja lei tributária específica sobre a matéria. 
+
+OPTIONS 
+
+A) Em dívida tributária composta por capital e juros, o pagamento imputar-se-á primeiro no capital e, depois, nos juros vencidos, salvo se a lei dispuser o contrário.
+
+B) Em dívida composta por capital e juros, o pagamento imputar-se-á primeiro nos juros vencidos e, depois, no capital, não importando a vontade das partes.
+
+C) Às compensações tributárias aplica-se subsidiariamente a regra de imputação estipulada no Código Civil, tendo em vista a ausência de lei tributária específica sobre a matéria.
+
+D) Às compensações tributárias não se aplica a regra de imputação de pagamentos estipulada no Código Civil, ainda que não haja lei tributária específica sobre a matéria. 
+
+---
+ENUM Questão 
 
 
 67- À luz do posicionamento consolidado pelo STF, assinale a opção que contém conduta inconstitucional da Fazenda Pública:
 
-   A. Exigência de depósito prévio como requisito de admissibilidade de ação judicial na qual se pretenda discutir exigibilidade de crédito tributário.
-   B. Recusa de bens ilíquidos oferecidos pelo contribuinte em garantia de execução fiscal.
-   C. Pedido de substituição da penhora em execução fiscal quando o contribuinte comprovadamente não detém capacidade econômica.
-   D. Lançamento de débito fiscal com exigibilidade suspensa a fim de prevenir a decadência.
+
+OPTIONS 
+
+A) Exigência de depósito prévio como requisito de admissibilidade de ação judicial na qual se pretenda discutir exigibilidade de crédito tributário.
+
+B) Recusa de bens ilíquidos oferecidos pelo contribuinte em garantia de execução fiscal.
+
+C) Pedido de substituição da penhora em execução fiscal quando o contribuinte comprovadamente não detém capacidade econômica.
+
+D) Lançamento de débito fiscal com exigibilidade suspensa a fim de prevenir a decadência.
+
+---
+ENUM Questão 
 
 
 68- Não se incluem na base de cálculo do ICMS:
 
- A. Prestação de serviço de transporte intermunicipal.
- B. Vendas de mercadorias a não contribuinte.
- C. Descontos incondicionais.
- D. Entrada de mercadoria importada do exterior.
+
+OPTIONS 
+
+A) Prestação de serviço de transporte intermunicipal.
+
+B) Vendas de mercadorias a não contribuinte.
+
+C) Descontos incondicionais.
+
+D) Entrada de mercadoria importada do exterior.
+
+---
+ENUM Questão 
 
 
 69-Assinale a alternativa correta quanto aos entendimentos sumulados pelos Tribunais Superiores:
 
-   A. O STF entende ser constitucional a incidência do ISS sobre operações de locação de bens móveis.
-   B. O STF entende ser constitucional a incidência do ISS sobre operações de locação de bens móveis, desde que a receita delas decorrentes não seja destinada a instituições em fins lucrativos.
-   C. O STF entende ser inconstitucional a incidência do ISS sobre operações de locação de bens móveis; todavia, a aplicação do referido posicionamento não é obrigatória pelos tribunais ordinários.
-   D. O STF entende ser inconstitucional a incidência do ISS sobre operações de locação de bens móveis, sendo que o referido posicionamento deve obrigatoriamente ser seguido por todos os tribunais que julgarem a matéria. 
+
+OPTIONS 
+
+A) O STF entende ser constitucional a incidência do ISS sobre operações de locação de bens móveis.
+
+B) O STF entende ser constitucional a incidência do ISS sobre operações de locação de bens móveis, desde que a receita delas decorrentes não seja destinada a instituições em fins lucrativos.
+
+C) O STF entende ser inconstitucional a incidência do ISS sobre operações de locação de bens móveis; todavia, a aplicação do referido posicionamento não é obrigatória pelos tribunais ordinários.
+
+D) O STF entende ser inconstitucional a incidência do ISS sobre operações de locação de bens móveis, sendo que o referido posicionamento deve obrigatoriamente ser seguido por todos os tribunais que julgarem a matéria. 
+
+---
+ENUM Questão 
 
 
 70- Quanto às imunidades tributárias, indique a alternativa incorreta conforme entendimento pacífico do STF:
 
- A. Quando alugado a terceiros, o imóvel pertencente às instituições de assistência social sem fins lucrativos não perde a imunidade ao IPTU, ainda que o valor dos aluguéis seja aplicado nas atividades essenciais destas entidades.
- B. Quando alugado a terceiros, o imóvel pertencente às instituições de assistência social sem fins lucrativos perde a imunidade ao IPTU, ainda que o valor dos aluguéis seja aplicado nas atividades essenciais destas entidades.
- C. Quando destinado a uso próprio, o imóvel pertencente às instituições de assistência social sem fins lucrativos tem imunidade em relação ao IPTU.
- D. Nenhuma das alternativas acima.
+
+OPTIONS 
+
+A) Quando alugado a terceiros, o imóvel pertencente às instituições de assistência social sem fins lucrativos não perde a imunidade ao IPTU, ainda que o valor dos aluguéis seja aplicado nas atividades essenciais destas entidades.
+
+B) Quando alugado a terceiros, o imóvel pertencente às instituições de assistência social sem fins lucrativos perde a imunidade ao IPTU, ainda que o valor dos aluguéis seja aplicado nas atividades essenciais destas entidades.
+
+C) Quando destinado a uso próprio, o imóvel pertencente às instituições de assistência social sem fins lucrativos tem imunidade em relação ao IPTU.
+
+D) Nenhuma das alternativas acima.
+
+---
+ENUM Questão 
 

--- a/simulated/raw/2011-5.txt
+++ b/simulated/raw/2011-5.txt
@@ -381,7 +381,7 @@ A. O ato processual praticado em desconformidade com a norma que disciplina sua 
 B. Deve ser decretada a nulidade do processo em que se tenha constatado, afinal, a falta de outorga uxória, ainda que se possa decidir o mérito a favor do cônjuge ausente, visto que todas as nulidades processuais são insanáveis.
 C. A nulidade relativa deve ser argüida pela parte interessada em sua decretação, na primeira oportunidade em que lhe couber falar nos autos, depois do ato defeituoso, sob pena de preclusão, isto é, de perda da faculdade processual de promover a anulação.
 D. Anulado um ato processual, mesmo que se trate de um ato complexo, todos os atos subseqüentes a ele serão também anulados, ainda que sejam independentes entre si e que a nulidade se refira a apenas uma parte do ato. 
-LETRA 
+
 50- Acerca da resposta do réu, assinale a opção correta.
 
 A. No caso de a incompetência do juízo, absoluta ou relativa, não ser alegada como preliminar na contestação, ocorrerá a chamada prorrogação de competência.

--- a/simulated/raw/clean_data_simulated.py
+++ b/simulated/raw/clean_data_simulated.py
@@ -1,0 +1,68 @@
+# encoding: utf-8
+#python3
+
+""" 
+
+O objetivo desse arquivo é tornar mais automático o processo de formatação e
+limpeza dos dados das provas simuladas pela FGV DIREITO RIO. Os arquivos de
+raw/simulated precisam ter o mesmo formato que os arquivos em raw/official.
+Esse processo não é totalmente automático, ainda será necessário ajustar
+manualmente os corner cases que esse script não resolve, como primeiro e último,
+inserir área e corrigir erros pontuais que não possuem um padrão.
+Posteriormente, será feito um outro script apenas para introduzir o gabarito.
+    
+"""
+
+# como boa prática vou ler as informações em um arquivo e escrever em outro
+file_object = open("2011-5.txt","r")
+
+# iterar sobre cada linha do arquivo que estou lendo
+for line in file_object:
+    
+    """
+    O comando lstrip() remove espaços no início da linha até
+    encontrar um caracter, como:
+    " Example"    -> "Example"
+    "  Example  " -> "Example  "
+    "    Example" -> "Example"
+    """
+    line = line.lstrip()
+
+    # as alternativas são seguidas de ")" no official/raw e não "."    
+    # além disso, aproveitar a alternativa "A" para inserir o marcador OPTIONS
+    if line[:3]=="A. ":
+            
+        line = line.replace("A. ","A) ")
+        
+        line = "OPTIONS \n" + "\n" + line
+    
+    if line[:3]=="B. ":
+            
+        line = line.replace("B. ","B) ")
+
+    if line[:3]=="C. ":
+            
+        line = line.replace("C. ","C) ")
+
+    """
+    As alternativas B e C foram arrumadas em relação ao "X) .".  No caso da
+    alternativa D, vou usá-la para inserir outros marcadores como "---" e "ENUM
+    Questão".  Atenção, vai faltar esse marcador na primeira questão e vai
+    sobrar no final um marcador solto. Vou, manualmente, acrescentar a primeira e
+    tirar o que sobrar.
+    """
+    if line[:3]=="D. ":
+            
+        line = line.replace("D. ","D) ")
+        
+        line = line  + "\n" + "---\n" + "ENUM Questão "   
+ 
+    print (line)
+
+"""
+para rodar o arquivo eu usei o comando no vim:
+
+:w |! python clean_data_simulated.py >> output_test.txt
+
+como dito anteriormente, leio em um arquivo e escrevo no outro
+"""

--- a/src/clean_data_simulated.py
+++ b/src/clean_data_simulated.py
@@ -1,0 +1,68 @@
+# encoding: utf-8
+#python3
+
+""" 
+
+O objetivo desse arquivo é tornar mais automático o processo de formatação e
+limpeza dos dados das provas simuladas pela FGV DIREITO RIO. Os arquivos de
+raw/simulated precisam ter o mesmo formato que os arquivos em raw/official.
+Esse processo não é totalmente automático, ainda será necessário ajustar
+manualmente os corner cases que esse script não resolve, como primeiro e último,
+inserir área e corrigir erros pontuais que não possuem um padrão.
+Posteriormente, será feito um outro script apenas para introduzir o gabarito.
+    
+"""
+
+# como boa prática vou ler as informações em um arquivo e escrever em outro
+file_object = open("2011-5.txt","r")
+
+# iterar sobre cada linha do arquivo que estou lendo
+for line in file_object:
+    
+    """
+    O comando lstrip() remove espaços no início da linha até
+    encontrar um caracter, como:
+    " Example"    -> "Example"
+    "  Example  " -> "Example  "
+    "    Example" -> "Example"
+    """
+    line = line.lstrip()
+
+    # as alternativas são seguidas de ")" no official/raw e não "."    
+    # além disso, aproveitar a alternativa "A" para inserir o marcador OPTIONS
+    if line[:3]=="A. ":
+            
+        line = line.replace("A. ","A) ")
+        
+        line = "OPTIONS \n" + "\n" + line
+    
+    if line[:3]=="B. ":
+            
+        line = line.replace("B. ","B) ")
+
+    if line[:3]=="C. ":
+            
+        line = line.replace("C. ","C) ")
+
+    """
+    As alternativas B e C foram arrumadas em relação ao "X) .".  No caso da
+    alternativa D, vou usá-la para inserir outros marcadores como "---" e "ENUM
+    Questão".  Atenção, vai faltar esse marcador na primeira questão e vai
+    sobrar no final um marcador solto. Vou, manualmente, acrescentar a primeira e
+    tirar o que sobrar.
+    """
+    if line[:3]=="D. ":
+            
+        line = line.replace("D. ","D) ")
+        
+        line = line  + "\n" + "---\n" + "ENUM Questão "   
+ 
+    print (line)
+
+"""
+para rodar o arquivo eu usei o comando no vim:
+
+:w |! python clean_data_simulated.py >> output_test.txt
+
+como dito anteriormente, leio em um arquivo e escrevo no outro
+"""


### PR DESCRIPTION
Fiz um script em Python para me ajudar na limpeza e inserção de marcadores nos arquivos simulated/raw.

Atualmente, o script faz as seguintes tarefas:

- formatar as alternativas "A. ", "B. " e etc no padrão de official/raw como "A) ", "B) " e etc;

- insere o marcador "OPTIONS" em cima da primeira alternativa;

- insere o marcador "---" antes de uma nova questão;

- insere o marcador "ENUM Questão " para anunciar uma nova questão; e

- remove whitespaces no início das linhas.

**Esse script não faz o processo de limpeza totalmente, apenas ajuda e acelera o processo.**

Ainda é necessário (i) fazer ajustes pontuais de erros que não possuem padrão, (ii) inserir a área das questões ( no caso dos simulados, as questões já vem separadas por área com a prova indicando é preciso apenas colocar no mesmo formato, em inglês, que official/raw) e **(iii) inserir o gabarito**.

Vou fazer um outro script para inserir o gabarito. Esse script será rodado **apenas** depois que o script clean_data já tiver rodado e que, manualmente, os pontos (i) e (ii) tenham sido corrigidos.